### PR TITLE
Added silk touch only breakable froglass panes

### DIFF
--- a/common/src/main/resources/data/naturalist/loot_tables/blocks/azure_froglass_pane.json
+++ b/common/src/main/resources/data/naturalist/loot_tables/blocks/azure_froglass_pane.json
@@ -1,0 +1,30 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "bonus_rolls": 0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "naturalist:azure_froglass_pane"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "enchantments": [
+              {
+                "enchantment": "minecraft:silk_touch",
+                "levels": {
+                  "min": 1
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/naturalist/loot_tables/blocks/crimson_froglass_pane.json
+++ b/common/src/main/resources/data/naturalist/loot_tables/blocks/crimson_froglass_pane.json
@@ -1,0 +1,30 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "bonus_rolls": 0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "naturalist:crimson_froglass_pane"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "enchantments": [
+              {
+                "enchantment": "minecraft:silk_touch",
+                "levels": {
+                  "min": 1
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/naturalist/loot_tables/blocks/verdant_froglass_pane.json
+++ b/common/src/main/resources/data/naturalist/loot_tables/blocks/verdant_froglass_pane.json
@@ -1,0 +1,30 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "bonus_rolls": 0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "naturalist:verdant_froglass_pane"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:match_tool",
+          "predicate": {
+            "enchantments": [
+              {
+                "enchantment": "minecraft:silk_touch",
+                "levels": {
+                  "min": 1
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I adjusted the loot table of the 3 froglass panes to make them shatter if broken without silk touch.

We could update 1.19.2 as well.