### PR TITLE
Improve cooked egg compatibility

### DIFF
--- a/common/src/main/resources/data/c/tags/items/eggs.json
+++ b/common/src/main/resources/data/c/tags/items/eggs.json
@@ -1,6 +1,8 @@
 {
   "replace": false,
   "values": [
+    "naturalist:tortoise_egg",
+    "naturalist:alligator_egg",
     "naturalist:duck_egg"
   ]
 }

--- a/common/src/main/resources/data/forge/tags/items/eggs.json
+++ b/common/src/main/resources/data/forge/tags/items/eggs.json
@@ -1,6 +1,8 @@
 {
   "replace": false,
   "values": [
+    "naturalist:tortoise_egg",
+    "naturalist:alligator_egg",
     "naturalist:duck_egg"
   ]
 }

--- a/common/src/main/resources/data/naturalist/recipes/cooked_egg.json
+++ b/common/src/main/resources/data/naturalist/recipes/cooked_egg.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:smelting",
   "ingredient": {
-    "tag": "naturalist:eggs"
+    "tag": "forge:eggs"
   },
   "result": "naturalist:cooked_egg",
   "experience": 0.35,

--- a/common/src/main/resources/data/naturalist/recipes/cooked_egg_from_campfire_cooking.json
+++ b/common/src/main/resources/data/naturalist/recipes/cooked_egg_from_campfire_cooking.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:campfire_cooking",
   "ingredient": {
-    "tag": "naturalist:eggs"
+    "tag": "forge:eggs"
   },
   "result": "naturalist:cooked_egg",
   "experience": 0.35,

--- a/common/src/main/resources/data/naturalist/recipes/cooked_egg_from_smoking.json
+++ b/common/src/main/resources/data/naturalist/recipes/cooked_egg_from_smoking.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:smoking",
   "ingredient": {
-    "tag": "naturalist:eggs"
+    "tag": "forge:eggs"
   },
   "result": "naturalist:cooked_egg",
   "experience": 0.35,

--- a/common/src/main/resources/data/naturalist/tags/items/eggs.json
+++ b/common/src/main/resources/data/naturalist/tags/items/eggs.json
@@ -1,5 +1,7 @@
 {
   "values": [
+    "naturalist:tortoise_egg",
+    "naturalist:alligator_egg",
     "naturalist:duck_egg",
     "minecraft:egg"
   ]


### PR DESCRIPTION
The cooked egg recipe currently can only take the Duck Egg and vanilla Egg. This pull request aims to give the recipe additional ingredients with the `forge:eggs` tag and adds the tortoise and alligator egg to the recipe as well, as thematically bird and reptile eggs of many varieties can be substituted for conventional chicken eggs. 

Other foods that take eggs use the `forge:eggs` tag, so it feels out of place for the cooked egg to be restricted to only two ingredients. 

There is one caveat to this change, [Alex's Mobs](https://github.com/AlexModGuy/AlexsMobs) has an Emu Egg with a cooking recipe that makes a [Boiled Emu Egg ](https://github.com/AlexModGuy/AlexsMobs/blob/1.20/src/main/resources/data/alexsmobs/recipes/boiled_emu_egg.json). I'm not sure if there is a way to specifically exclude this item so Naturalist's recipe doesn't override it, but I believe these changes are overall an improvement for mod compatibility.