### PR TITLE
Add Terralith biome compatibility to Naturalist spawn tags

### DIFF
--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_alligator.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_alligator.json
@@ -14,6 +14,26 @@
     {
       "id": "biomesoplenty:bayou",
       "required": false
+    },
+    {
+      "id": "terralith:orchid_swamp",
+      "required": false
+    },
+    {
+      "id": "terralith:ice_marsh",
+      "required": false
+    },
+    {
+      "id": "terralith:warm_river",
+      "required": false
+    },
+    {
+      "id": "terralith:desert_oasis",
+      "required": false
+    },
+    {
+      "id": "terralith:red_oasis",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_bass.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_bass.json
@@ -18,6 +18,26 @@
     {
       "id": "biomesoplenty:wetland",
       "required": false
+    },
+    {
+      "id": "terralith:orchid_swamp",
+      "required": false
+    },
+    {
+      "id": "terralith:ice_marsh",
+      "required": false
+    },
+    {
+      "id": "terralith:warm_river",
+      "required": false
+    },
+    {
+      "id": "terralith:desert_oasis",
+      "required": false
+    },
+    {
+      "id": "terralith:red_oasis",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_bear.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_bear.json
@@ -49,6 +49,54 @@
     {
       "id": "biomesoplenty:snowy_maple_woods",
       "required": false
+    },
+    {
+      "id": "terralith:birch_taiga",
+      "required": false
+    },
+    {
+      "id": "terralith:cloud_forest",
+      "required": false
+    },
+    {
+      "id": "terralith:forested_highlands",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_forest",
+      "required": false
+    },
+    {
+      "id": "terralith:moonlight_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:moonlight_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:snowy_maple_forest",
+      "required": false
+    },
+    {
+      "id": "terralith:temperate_highlands",
+      "required": false
+    },
+    {
+      "id": "terralith:wintry_forest",
+      "required": false
+    },
+    {
+      "id": "terralith:yellowstone",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_bluejay.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_bluejay.json
@@ -64,6 +64,62 @@
     {
       "id": "biomesoplenty:muskeg",
       "required": false
+    },
+    {
+      "id": "terralith:alpine_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:alpine_highlands",
+      "required": false
+    },
+    {
+      "id": "terralith:birch_taiga",
+      "required": false
+    },
+    {
+      "id": "terralith:emerald_peaks",
+      "required": false
+    },
+    {
+      "id": "terralith:forested_highlands",
+      "required": false
+    },
+    {
+      "id": "terralith:haze_mountain",
+      "required": false
+    },
+    {
+      "id": "terralith:highlands",
+      "required": false
+    },
+    {
+      "id": "terralith:rocky_mountains",
+      "required": false
+    },
+    {
+      "id": "terralith:scarlet_mountains",
+      "required": false
+    },
+    {
+      "id": "terralith:snowy_maple_forest",
+      "required": false
+    },
+    {
+      "id": "terralith:stony_spires",
+      "required": false
+    },
+    {
+      "id": "terralith:temperate_highlands",
+      "required": false
+    },
+    {
+      "id": "terralith:white_cliffs",
+      "required": false
+    },
+    {
+      "id": "terralith:wintry_forest",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_boar.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_boar.json
@@ -21,6 +21,54 @@
     {
       "id": "biomesoplenty:woodland",
       "required": false
+    },
+    {
+      "id": "terralith:brushland",
+      "required": false
+    },
+    {
+      "id": "terralith:cold_shrubland",
+      "required": false
+    },
+    {
+      "id": "terralith:forested_highlands",
+      "required": false
+    },
+    {
+      "id": "terralith:hot_shrubland",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_forest",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:moonlight_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:moonlight_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:shrubland",
+      "required": false
+    },
+    {
+      "id": "terralith:temperate_highlands",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_butterfly.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_butterfly.json
@@ -51,6 +51,50 @@
     {
       "id": "biomesoplenty:shrubland",
       "required": false
+    },
+    {
+      "id": "terralith:blooming_plateau",
+      "required": false
+    },
+    {
+      "id": "terralith:blooming_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:brushland",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_forest",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:moonlight_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:moonlight_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:orchid_swamp",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:shrubland",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_canary.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_canary.json
@@ -21,6 +21,50 @@
     {
       "id": "biomesoplenty:moor",
       "required": false
+    },
+    {
+      "id": "terralith:alpine_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:alpine_highlands",
+      "required": false
+    },
+    {
+      "id": "terralith:emerald_peaks",
+      "required": false
+    },
+    {
+      "id": "terralith:haze_mountain",
+      "required": false
+    },
+    {
+      "id": "terralith:highlands",
+      "required": false
+    },
+    {
+      "id": "terralith:painted_mountains",
+      "required": false
+    },
+    {
+      "id": "terralith:rocky_mountains",
+      "required": false
+    },
+    {
+      "id": "terralith:scarlet_mountains",
+      "required": false
+    },
+    {
+      "id": "terralith:stony_spires",
+      "required": false
+    },
+    {
+      "id": "terralith:temperate_highlands",
+      "required": false
+    },
+    {
+      "id": "terralith:white_cliffs",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_cardinal.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_cardinal.json
@@ -56,6 +56,62 @@
     {
       "id": "biomesoplenty:wetland",
       "required": false
+    },
+    {
+      "id": "terralith:blooming_plateau",
+      "required": false
+    },
+    {
+      "id": "terralith:blooming_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:brushland",
+      "required": false
+    },
+    {
+      "id": "terralith:desert_oasis",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_forest",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:lush_desert",
+      "required": false
+    },
+    {
+      "id": "terralith:moonlight_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:moonlight_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:orchid_swamp",
+      "required": false
+    },
+    {
+      "id": "terralith:red_oasis",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:shrubland",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_catfish.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_catfish.json
@@ -17,6 +17,26 @@
     {
       "id": "biomesoplenty:wetland",
       "required": false
+    },
+    {
+      "id": "terralith:orchid_swamp",
+      "required": false
+    },
+    {
+      "id": "terralith:ice_marsh",
+      "required": false
+    },
+    {
+      "id": "terralith:warm_river",
+      "required": false
+    },
+    {
+      "id": "terralith:desert_oasis",
+      "required": false
+    },
+    {
+      "id": "terralith:red_oasis",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_coral_snake.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_coral_snake.json
@@ -19,6 +19,26 @@
     {
       "id": "biomesoplenty:rainforest",
       "required": false
+    },
+    {
+      "id": "terralith:amethyst_rainforest",
+      "required": false
+    },
+    {
+      "id": "terralith:jungle_mountains",
+      "required": false
+    },
+    {
+      "id": "terralith:rocky_jungle",
+      "required": false
+    },
+    {
+      "id": "terralith:tropical_jungle",
+      "required": false
+    },
+    {
+      "id": "terralith:warm_river",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_deer.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_deer.json
@@ -45,6 +45,62 @@
     {
       "id": "biomesoplenty:mystic_grove",
       "required": false
+    },
+    {
+      "id": "terralith:birch_taiga",
+      "required": false
+    },
+    {
+      "id": "terralith:blooming_plateau",
+      "required": false
+    },
+    {
+      "id": "terralith:blooming_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:cloud_forest",
+      "required": false
+    },
+    {
+      "id": "terralith:forested_highlands",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_forest",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:moonlight_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:moonlight_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:snowy_maple_forest",
+      "required": false
+    },
+    {
+      "id": "terralith:temperate_highlands",
+      "required": false
+    },
+    {
+      "id": "terralith:wintry_forest",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_dragonfly.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_dragonfly.json
@@ -9,6 +9,26 @@
     {
       "id": "biomesoplenty:bayou",
       "required": false
+    },
+    {
+      "id": "terralith:orchid_swamp",
+      "required": false
+    },
+    {
+      "id": "terralith:ice_marsh",
+      "required": false
+    },
+    {
+      "id": "terralith:warm_river",
+      "required": false
+    },
+    {
+      "id": "terralith:desert_oasis",
+      "required": false
+    },
+    {
+      "id": "terralith:red_oasis",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_duck.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_duck.json
@@ -29,6 +29,42 @@
     {
       "id": "biomesoplenty:shrubland",
       "required": false
+    },
+    {
+      "id": "terralith:blooming_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:brushland",
+      "required": false
+    },
+    {
+      "id": "terralith:ice_marsh",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:moonlight_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:orchid_swamp",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:shrubland",
+      "required": false
+    },
+    {
+      "id": "terralith:warm_river",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_elephant.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_elephant.json
@@ -8,6 +8,18 @@
     {
       "id": "biomesoplenty:scrubland",
       "required": false
+    },
+    {
+      "id": "terralith:ashen_savanna",
+      "required": false
+    },
+    {
+      "id": "terralith:savanna_badlands",
+      "required": false
+    },
+    {
+      "id": "terralith:savanna_slopes",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_finch.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_finch.json
@@ -21,6 +21,38 @@
     {
       "id": "biomesoplenty:scrubland",
       "required": false
+    },
+    {
+      "id": "terralith:brushland",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_forest",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:savanna_badlands",
+      "required": false
+    },
+    {
+      "id": "terralith:savanna_slopes",
+      "required": false
+    },
+    {
+      "id": "terralith:shrubland",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_firefly.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_firefly.json
@@ -56,6 +56,50 @@
     {
       "id": "biomesoplenty:wetland",
       "required": false
+    },
+    {
+      "id": "terralith:blooming_plateau",
+      "required": false
+    },
+    {
+      "id": "terralith:blooming_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_forest",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:moonlight_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:moonlight_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:orchid_swamp",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:shrubland",
+      "required": false
+    },
+    {
+      "id": "terralith:wintry_forest",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_giraffe.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_giraffe.json
@@ -8,6 +8,18 @@
     {
       "id": "biomesoplenty:scrubland",
       "required": false
+    },
+    {
+      "id": "terralith:ashen_savanna",
+      "required": false
+    },
+    {
+      "id": "terralith:savanna_badlands",
+      "required": false
+    },
+    {
+      "id": "terralith:savanna_slopes",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_hippo.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_hippo.json
@@ -13,6 +13,26 @@
     {
       "id": "#atmospheric:is_rainforest",
       "required": false
+    },
+    {
+      "id": "terralith:amethyst_rainforest",
+      "required": false
+    },
+    {
+      "id": "terralith:orchid_swamp",
+      "required": false
+    },
+    {
+      "id": "terralith:rocky_jungle",
+      "required": false
+    },
+    {
+      "id": "terralith:tropical_jungle",
+      "required": false
+    },
+    {
+      "id": "terralith:warm_river",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_lion.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_lion.json
@@ -8,6 +8,18 @@
     {
       "id": "biomesoplenty:scrubland",
       "required": false
+    },
+    {
+      "id": "terralith:ashen_savanna",
+      "required": false
+    },
+    {
+      "id": "terralith:savanna_badlands",
+      "required": false
+    },
+    {
+      "id": "terralith:savanna_slopes",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_lizard.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_lizard.json
@@ -33,6 +33,62 @@
     {
       "id": "biomesoplenty:rainforest",
       "required": false
+    },
+    {
+      "id": "terralith:amethyst_rainforest",
+      "required": false
+    },
+    {
+      "id": "terralith:brushland",
+      "required": false
+    },
+    {
+      "id": "terralith:desert_canyon",
+      "required": false
+    },
+    {
+      "id": "terralith:desert_oasis",
+      "required": false
+    },
+    {
+      "id": "terralith:desert_spires",
+      "required": false
+    },
+    {
+      "id": "terralith:hot_shrubland",
+      "required": false
+    },
+    {
+      "id": "terralith:jungle_mountains",
+      "required": false
+    },
+    {
+      "id": "terralith:lush_desert",
+      "required": false
+    },
+    {
+      "id": "terralith:rocky_jungle",
+      "required": false
+    },
+    {
+      "id": "terralith:savanna_badlands",
+      "required": false
+    },
+    {
+      "id": "terralith:savanna_slopes",
+      "required": false
+    },
+    {
+      "id": "terralith:shrubland",
+      "required": false
+    },
+    {
+      "id": "terralith:tropical_jungle",
+      "required": false
+    },
+    {
+      "id": "terralith:warped_mesa",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_rattlesnake.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_rattlesnake.json
@@ -22,6 +22,54 @@
     {
       "id": "biomesoplenty:scrubland",
       "required": false
+    },
+    {
+      "id": "terralith:ancient_sands",
+      "required": false
+    },
+    {
+      "id": "terralith:desert_canyon",
+      "required": false
+    },
+    {
+      "id": "terralith:desert_oasis",
+      "required": false
+    },
+    {
+      "id": "terralith:desert_spires",
+      "required": false
+    },
+    {
+      "id": "terralith:gravel_desert",
+      "required": false
+    },
+    {
+      "id": "terralith:hot_shrubland",
+      "required": false
+    },
+    {
+      "id": "terralith:lush_desert",
+      "required": false
+    },
+    {
+      "id": "terralith:painted_mountains",
+      "required": false
+    },
+    {
+      "id": "terralith:red_oasis",
+      "required": false
+    },
+    {
+      "id": "terralith:savanna_badlands",
+      "required": false
+    },
+    {
+      "id": "terralith:savanna_slopes",
+      "required": false
+    },
+    {
+      "id": "terralith:warped_mesa",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_rhino.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_rhino.json
@@ -8,6 +8,18 @@
     {
       "id": "biomesoplenty:scrubland",
       "required": false
+    },
+    {
+      "id": "terralith:ashen_savanna",
+      "required": false
+    },
+    {
+      "id": "terralith:savanna_badlands",
+      "required": false
+    },
+    {
+      "id": "terralith:savanna_slopes",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_robin.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_robin.json
@@ -39,6 +39,54 @@
     {
       "id": "biomesoplenty:seasonal_forest",
       "required": false
+    },
+    {
+      "id": "terralith:blooming_plateau",
+      "required": false
+    },
+    {
+      "id": "terralith:blooming_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:cloud_forest",
+      "required": false
+    },
+    {
+      "id": "terralith:forested_highlands",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_forest",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:moonlight_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:moonlight_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:temperate_highlands",
+      "required": false
+    },
+    {
+      "id": "terralith:white_cliffs",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_snail.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_snail.json
@@ -66,6 +66,78 @@
     {
       "id": "biomesoplenty:woodland",
       "required": false
+    },
+    {
+      "id": "terralith:alpine_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:blooming_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:brushland",
+      "required": false
+    },
+    {
+      "id": "terralith:cloud_forest",
+      "required": false
+    },
+    {
+      "id": "terralith:forested_highlands",
+      "required": false
+    },
+    {
+      "id": "terralith:ice_marsh",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_forest",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:moonlight_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:moonlight_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:orchid_swamp",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:shrubland",
+      "required": false
+    },
+    {
+      "id": "terralith:temperate_highlands",
+      "required": false
+    },
+    {
+      "id": "terralith:warm_river",
+      "required": false
+    },
+    {
+      "id": "terralith:wintry_forest",
+      "required": false
+    },
+    {
+      "id": "terralith:yellowstone",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_snake.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_snake.json
@@ -31,6 +31,62 @@
     {
       "id": "biomesoplenty:lavender_field",
       "required": false
+    },
+    {
+      "id": "terralith:blooming_plateau",
+      "required": false
+    },
+    {
+      "id": "terralith:blooming_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:brushland",
+      "required": false
+    },
+    {
+      "id": "terralith:forested_highlands",
+      "required": false
+    },
+    {
+      "id": "terralith:hot_shrubland",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_forest",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:moonlight_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:moonlight_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:orchid_swamp",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_grove",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:shrubland",
+      "required": false
+    },
+    {
+      "id": "terralith:warm_river",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_sparrow.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_sparrow.json
@@ -21,6 +21,34 @@
     {
       "id": "biomesoplenty:shrubland",
       "required": false
+    },
+    {
+      "id": "terralith:blooming_plateau",
+      "required": false
+    },
+    {
+      "id": "terralith:blooming_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:brushland",
+      "required": false
+    },
+    {
+      "id": "terralith:cold_shrubland",
+      "required": false
+    },
+    {
+      "id": "terralith:lavender_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:sakura_valley",
+      "required": false
+    },
+    {
+      "id": "terralith:shrubland",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_tortoise.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_tortoise.json
@@ -27,6 +27,34 @@
     {
       "id": "biomesoplenty:bayou",
       "required": false
+    },
+    {
+      "id": "terralith:amethyst_rainforest",
+      "required": false
+    },
+    {
+      "id": "terralith:desert_oasis",
+      "required": false
+    },
+    {
+      "id": "terralith:lush_desert",
+      "required": false
+    },
+    {
+      "id": "terralith:orchid_swamp",
+      "required": false
+    },
+    {
+      "id": "terralith:red_oasis",
+      "required": false
+    },
+    {
+      "id": "terralith:rocky_jungle",
+      "required": false
+    },
+    {
+      "id": "terralith:tropical_jungle",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_vulture.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_vulture.json
@@ -30,6 +30,54 @@
     {
       "id": "biomesoplenty:scrubland",
       "required": false
+    },
+    {
+      "id": "terralith:ancient_sands",
+      "required": false
+    },
+    {
+      "id": "terralith:ashen_savanna",
+      "required": false
+    },
+    {
+      "id": "terralith:bryce_canyon",
+      "required": false
+    },
+    {
+      "id": "terralith:desert_canyon",
+      "required": false
+    },
+    {
+      "id": "terralith:desert_spires",
+      "required": false
+    },
+    {
+      "id": "terralith:gravel_desert",
+      "required": false
+    },
+    {
+      "id": "terralith:hot_shrubland",
+      "required": false
+    },
+    {
+      "id": "terralith:lush_desert",
+      "required": false
+    },
+    {
+      "id": "terralith:painted_mountains",
+      "required": false
+    },
+    {
+      "id": "terralith:savanna_badlands",
+      "required": false
+    },
+    {
+      "id": "terralith:savanna_slopes",
+      "required": false
+    },
+    {
+      "id": "terralith:warped_mesa",
+      "required": false
     }
   ]
 }

--- a/src/generated/resources/data/naturalist/tags/worldgen/biome/has_zebra.json
+++ b/src/generated/resources/data/naturalist/tags/worldgen/biome/has_zebra.json
@@ -8,6 +8,18 @@
     {
       "id": "biomesoplenty:scrubland",
       "required": false
+    },
+    {
+      "id": "terralith:ashen_savanna",
+      "required": false
+    },
+    {
+      "id": "terralith:savanna_badlands",
+      "required": false
+    },
+    {
+      "id": "terralith:savanna_slopes",
+      "required": false
     }
   ]
 }

--- a/src/main/java/com/starfish_studios/naturalist/datagen/NaturalistBiomeTagsProvider.java
+++ b/src/main/java/com/starfish_studios/naturalist/datagen/NaturalistBiomeTagsProvider.java
@@ -26,6 +26,10 @@ public class NaturalistBiomeTagsProvider extends TagsProvider<Biome> {
         return ResourceLocation.fromNamespaceAndPath("biomesoplenty", name);
     }
 
+    private static ResourceLocation terralith(String name) {
+        return ResourceLocation.fromNamespaceAndPath("terralith", name);
+    }
+
     public NaturalistBiomeTagsProvider(PackOutput output, CompletableFuture<HolderLookup.Provider> lookupProvider, @Nullable ExistingFileHelper existingFileHelper) {
         super(output, Registries.BIOME, lookupProvider, Naturalist.MOD_ID, existingFileHelper);
     }
@@ -36,13 +40,23 @@ public class NaturalistBiomeTagsProvider extends TagsProvider<Biome> {
                 .add(Biomes.SWAMP).add(Biomes.MANGROVE_SWAMP).add(Biomes.RIVER)
                 .addOptionalTag(Tags.Biomes.IS_SWAMP)
                 .addOptionalTag(ATMOSPHERIC_IS_RAINFOREST)
-                .addOptional(bop("bayou"));
+                .addOptional(bop("bayou"))
+                .addOptional(terralith("orchid_swamp"))
+                .addOptional(terralith("ice_marsh"))
+                .addOptional(terralith("warm_river"))
+                .addOptional(terralith("desert_oasis"))
+                .addOptional(terralith("red_oasis"));
 
         tag(NaturalistTags.Biomes.HAS_BASS)
                 .add(Biomes.SWAMP).add(Biomes.MANGROVE_SWAMP)
                 .addTag(BiomeTags.IS_RIVER)
                 .addOptionalTag(Tags.Biomes.IS_SWAMP)
-                .addOptional(bop("bayou")).addOptional(bop("bog")).addOptional(bop("wetland"));
+                .addOptional(bop("bayou")).addOptional(bop("bog")).addOptional(bop("wetland"))
+                .addOptional(terralith("orchid_swamp"))
+                .addOptional(terralith("ice_marsh"))
+                .addOptional(terralith("warm_river"))
+                .addOptional(terralith("desert_oasis"))
+                .addOptional(terralith("red_oasis"));
 
         tag(NaturalistTags.Biomes.HAS_BEAR)
                 .addTag(BiomeTags.IS_FOREST).addTag(BiomeTags.IS_TAIGA)
@@ -51,7 +65,19 @@ public class NaturalistBiomeTagsProvider extends TagsProvider<Biome> {
                 .addOptional(bop("orchard")).addOptional(bop("pumpkin_patch"))
                 .addOptional(bop("seasonal_forest")).addOptional(bop("woodland"))
                 .addOptional(bop("snowy_coniferous_forest")).addOptional(bop("fir_clearing"))
-                .addOptional(bop("maple_woods")).addOptional(bop("snowy_maple_woods"));
+                .addOptional(bop("maple_woods")).addOptional(bop("snowy_maple_woods"))
+                .addOptional(terralith("birch_taiga"))
+                .addOptional(terralith("cloud_forest"))
+                .addOptional(terralith("forested_highlands"))
+                .addOptional(terralith("lavender_forest"))
+                .addOptional(terralith("moonlight_grove"))
+                .addOptional(terralith("moonlight_valley"))
+                .addOptional(terralith("sakura_grove"))
+                .addOptional(terralith("sakura_valley"))
+                .addOptional(terralith("snowy_maple_forest"))
+                .addOptional(terralith("temperate_highlands"))
+                .addOptional(terralith("wintry_forest"))
+                .addOptional(terralith("yellowstone"));
 
         tag(NaturalistTags.Biomes.HAS_BLUEJAY)
                 .addTag(BiomeTags.IS_TAIGA).addTag(BiomeTags.IS_HILL)
@@ -63,13 +89,39 @@ public class NaturalistBiomeTagsProvider extends TagsProvider<Biome> {
                 .addOptional(bop("snowy_coniferous_forest")).addOptional(bop("coniferous_forest"))
                 .addOptional(bop("highland")).addOptional(bop("jade_cliffs"))
                 .addOptional(bop("maple_woods")).addOptional(bop("snowy_maple_woods"))
-                .addOptional(bop("moor")).addOptional(bop("muskeg"));
+                .addOptional(bop("moor")).addOptional(bop("muskeg"))
+                .addOptional(terralith("alpine_grove"))
+                .addOptional(terralith("alpine_highlands"))
+                .addOptional(terralith("birch_taiga"))
+                .addOptional(terralith("emerald_peaks"))
+                .addOptional(terralith("forested_highlands"))
+                .addOptional(terralith("haze_mountain"))
+                .addOptional(terralith("highlands"))
+                .addOptional(terralith("rocky_mountains"))
+                .addOptional(terralith("scarlet_mountains"))
+                .addOptional(terralith("snowy_maple_forest"))
+                .addOptional(terralith("stony_spires"))
+                .addOptional(terralith("temperate_highlands"))
+                .addOptional(terralith("white_cliffs"))
+                .addOptional(terralith("wintry_forest"));
 
         tag(NaturalistTags.Biomes.HAS_BOAR)
                 .addTag(BiomeTags.IS_SAVANNA).addTag(BiomeTags.IS_FOREST)
                 .addOptionalTag(Tags.Biomes.IS_SAVANNA)
                 .addOptional(bop("prairie")).addOptional(bop("rocky_shrubland"))
-                .addOptional(bop("shrubland")).addOptional(bop("woodland"));
+                .addOptional(bop("shrubland")).addOptional(bop("woodland"))
+                .addOptional(terralith("brushland"))
+                .addOptional(terralith("cold_shrubland"))
+                .addOptional(terralith("forested_highlands"))
+                .addOptional(terralith("hot_shrubland"))
+                .addOptional(terralith("lavender_forest"))
+                .addOptional(terralith("lavender_valley"))
+                .addOptional(terralith("moonlight_grove"))
+                .addOptional(terralith("moonlight_valley"))
+                .addOptional(terralith("sakura_grove"))
+                .addOptional(terralith("sakura_valley"))
+                .addOptional(terralith("shrubland"))
+                .addOptional(terralith("temperate_highlands"));
 
         tag(NaturalistTags.Biomes.HAS_BUTTERFLY)
                 .addTag(BiomeTags.IS_FOREST)
@@ -80,12 +132,34 @@ public class NaturalistBiomeTagsProvider extends TagsProvider<Biome> {
                 .addOptional(bop("lavender_field")).addOptional(bop("mystic_grove"))
                 .addOptional(bop("overgrown_greens")).addOptional(bop("pasture"))
                 .addOptional(bop("prairie")).addOptional(bop("rocky_shrubland"))
-                .addOptional(bop("shrubland"));
+                .addOptional(bop("shrubland"))
+                .addOptional(terralith("blooming_plateau"))
+                .addOptional(terralith("blooming_valley"))
+                .addOptional(terralith("brushland"))
+                .addOptional(terralith("lavender_forest"))
+                .addOptional(terralith("lavender_valley"))
+                .addOptional(terralith("moonlight_grove"))
+                .addOptional(terralith("moonlight_valley"))
+                .addOptional(terralith("orchid_swamp"))
+                .addOptional(terralith("sakura_grove"))
+                .addOptional(terralith("sakura_valley"))
+                .addOptional(terralith("shrubland"));
 
         tag(NaturalistTags.Biomes.HAS_CANARY)
                 .addTag(BiomeTags.IS_HILL).addTag(BiomeTags.IS_MOUNTAIN)
                 .addOptionalTag(Tags.Biomes.IS_MOUNTAIN).addOptionalTag(Tags.Biomes.IS_HILL)
-                .addOptional(bop("crag")).addOptional(bop("jade_cliffs")).addOptional(bop("moor"));
+                .addOptional(bop("crag")).addOptional(bop("jade_cliffs")).addOptional(bop("moor"))
+                .addOptional(terralith("alpine_grove"))
+                .addOptional(terralith("alpine_highlands"))
+                .addOptional(terralith("emerald_peaks"))
+                .addOptional(terralith("haze_mountain"))
+                .addOptional(terralith("highlands"))
+                .addOptional(terralith("painted_mountains"))
+                .addOptional(terralith("rocky_mountains"))
+                .addOptional(terralith("scarlet_mountains"))
+                .addOptional(terralith("stony_spires"))
+                .addOptional(terralith("temperate_highlands"))
+                .addOptional(terralith("white_cliffs"));
 
         tag(NaturalistTags.Biomes.HAS_CARDINAL)
                 .addTag(BiomeTags.IS_FOREST).addTag(BiomeTags.IS_SAVANNA)
@@ -96,19 +170,43 @@ public class NaturalistBiomeTagsProvider extends TagsProvider<Biome> {
                 .addOptional(bop("bayou")).addOptional(bop("bog"))
                 .addOptional(bop("lavender_field")).addOptional(bop("maple_woods"))
                 .addOptional(bop("mystic_grove")).addOptional(bop("orchard"))
-                .addOptional(bop("overgrown_greens")).addOptional(bop("wetland"));
+                .addOptional(bop("overgrown_greens")).addOptional(bop("wetland"))
+                .addOptional(terralith("blooming_plateau"))
+                .addOptional(terralith("blooming_valley"))
+                .addOptional(terralith("brushland"))
+                .addOptional(terralith("desert_oasis"))
+                .addOptional(terralith("lavender_forest"))
+                .addOptional(terralith("lavender_valley"))
+                .addOptional(terralith("lush_desert"))
+                .addOptional(terralith("moonlight_grove"))
+                .addOptional(terralith("moonlight_valley"))
+                .addOptional(terralith("orchid_swamp"))
+                .addOptional(terralith("red_oasis"))
+                .addOptional(terralith("sakura_grove"))
+                .addOptional(terralith("sakura_valley"))
+                .addOptional(terralith("shrubland"));
 
         tag(NaturalistTags.Biomes.HAS_CATFISH)
                 .add(Biomes.SWAMP).add(Biomes.MANGROVE_SWAMP)
                 .addOptionalTag(Tags.Biomes.IS_SWAMP)
-                .addOptional(bop("bayou")).addOptional(bop("bog")).addOptional(bop("wetland"));
+                .addOptional(bop("bayou")).addOptional(bop("bog")).addOptional(bop("wetland"))
+                .addOptional(terralith("orchid_swamp"))
+                .addOptional(terralith("ice_marsh"))
+                .addOptional(terralith("warm_river"))
+                .addOptional(terralith("desert_oasis"))
+                .addOptional(terralith("red_oasis"));
 
         tag(NaturalistTags.Biomes.HAS_CORAL_SNAKE)
                 .addTag(BiomeTags.IS_JUNGLE).addTag(BiomeTags.IS_RIVER)
                 .add(Biomes.BEACH).add(Biomes.STONY_SHORE)
                 .addOptionalTag(Tags.Biomes.IS_BEACH).addOptionalTag(Tags.Biomes.IS_JUNGLE)
                 .addOptionalTag(Tags.Biomes.IS_RIVER)
-                .addOptional(bop("rainforest"));
+                .addOptional(bop("rainforest"))
+                .addOptional(terralith("amethyst_rainforest"))
+                .addOptional(terralith("jungle_mountains"))
+                .addOptional(terralith("rocky_jungle"))
+                .addOptional(terralith("tropical_jungle"))
+                .addOptional(terralith("warm_river"));
 
         tag(NaturalistTags.Biomes.HAS_DEER)
                 .addTag(BiomeTags.IS_FOREST).add(Biomes.CHERRY_GROVE)
@@ -117,30 +215,69 @@ public class NaturalistBiomeTagsProvider extends TagsProvider<Biome> {
                 .addOptional(bop("redwood_forest")).addOptional(bop("woodland"))
                 .addOptional(bop("snowy_coniferous_forest")).addOptional(bop("snowy_fir_clearing"))
                 .addOptional(bop("snowblossom_grove")).addOptional(bop("snowy_maple_woods"))
-                .addOptional(bop("lavender_field")).addOptional(bop("mystic_grove"));
+                .addOptional(bop("lavender_field")).addOptional(bop("mystic_grove"))
+                .addOptional(terralith("birch_taiga"))
+                .addOptional(terralith("blooming_plateau"))
+                .addOptional(terralith("blooming_valley"))
+                .addOptional(terralith("cloud_forest"))
+                .addOptional(terralith("forested_highlands"))
+                .addOptional(terralith("lavender_forest"))
+                .addOptional(terralith("lavender_valley"))
+                .addOptional(terralith("moonlight_grove"))
+                .addOptional(terralith("moonlight_valley"))
+                .addOptional(terralith("sakura_grove"))
+                .addOptional(terralith("sakura_valley"))
+                .addOptional(terralith("snowy_maple_forest"))
+                .addOptional(terralith("temperate_highlands"))
+                .addOptional(terralith("wintry_forest"));
 
         tag(NaturalistTags.Biomes.HAS_DRAGONFLY)
                 .add(Biomes.SWAMP).add(Biomes.MANGROVE_SWAMP)
                 .addOptionalTag(Tags.Biomes.IS_SWAMP)
-                .addOptional(bop("bayou"));
+                .addOptional(bop("bayou"))
+                .addOptional(terralith("orchid_swamp"))
+                .addOptional(terralith("ice_marsh"))
+                .addOptional(terralith("warm_river"))
+                .addOptional(terralith("desert_oasis"))
+                .addOptional(terralith("red_oasis"));
 
         tag(NaturalistTags.Biomes.HAS_DUCK)
                 .add(Biomes.SWAMP).addTag(BiomeTags.IS_RIVER)
                 .addOptionalTag(Tags.Biomes.IS_SWAMP)
                 .addOptional(bop("lavender_field")).addOptional(bop("mystic_grove"))
                 .addOptional(bop("orchard")).addOptional(bop("prairie"))
-                .addOptional(bop("rocky_shrubland")).addOptional(bop("shrubland"));
+                .addOptional(bop("rocky_shrubland")).addOptional(bop("shrubland"))
+                .addOptional(terralith("blooming_valley"))
+                .addOptional(terralith("brushland"))
+                .addOptional(terralith("ice_marsh"))
+                .addOptional(terralith("lavender_valley"))
+                .addOptional(terralith("moonlight_valley"))
+                .addOptional(terralith("orchid_swamp"))
+                .addOptional(terralith("sakura_valley"))
+                .addOptional(terralith("shrubland"))
+                .addOptional(terralith("warm_river"));
 
         tag(NaturalistTags.Biomes.HAS_ELEPHANT)
                 .addTag(BiomeTags.IS_SAVANNA)
                 .addOptionalTag(Tags.Biomes.IS_SAVANNA)
-                .addOptional(bop("scrubland"));
+                .addOptional(bop("scrubland"))
+                .addOptional(terralith("ashen_savanna"))
+                .addOptional(terralith("savanna_badlands"))
+                .addOptional(terralith("savanna_slopes"));
 
         tag(NaturalistTags.Biomes.HAS_FINCH)
                 .addTag(BiomeTags.IS_SAVANNA).addTag(BiomeTags.IS_FOREST)
                 .addOptionalTag(Tags.Biomes.IS_FOREST).addOptionalTag(Tags.Biomes.IS_SAVANNA)
                 .addOptional(bop("lavender_field")).addOptional(bop("mediterranean_forest"))
-                .addOptional(bop("scrubland"));
+                .addOptional(bop("scrubland"))
+                .addOptional(terralith("brushland"))
+                .addOptional(terralith("lavender_forest"))
+                .addOptional(terralith("lavender_valley"))
+                .addOptional(terralith("sakura_grove"))
+                .addOptional(terralith("sakura_valley"))
+                .addOptional(terralith("savanna_badlands"))
+                .addOptional(terralith("savanna_slopes"))
+                .addOptional(terralith("shrubland"));
 
         tag(NaturalistTags.Biomes.HAS_FIREFLY)
                 .addTag(BiomeTags.IS_FOREST)
@@ -151,22 +288,44 @@ public class NaturalistBiomeTagsProvider extends TagsProvider<Biome> {
                 .addOptional(bop("lavender_field")).addOptional(bop("mystic_grove"))
                 .addOptional(bop("orchard")).addOptional(bop("pasture"))
                 .addOptional(bop("rocky_shrubland")).addOptional(bop("shrubland"))
-                .addOptional(bop("wetland"));
+                .addOptional(bop("wetland"))
+                .addOptional(terralith("blooming_plateau"))
+                .addOptional(terralith("blooming_valley"))
+                .addOptional(terralith("lavender_forest"))
+                .addOptional(terralith("lavender_valley"))
+                .addOptional(terralith("moonlight_grove"))
+                .addOptional(terralith("moonlight_valley"))
+                .addOptional(terralith("orchid_swamp"))
+                .addOptional(terralith("sakura_grove"))
+                .addOptional(terralith("sakura_valley"))
+                .addOptional(terralith("shrubland"))
+                .addOptional(terralith("wintry_forest"));
 
         tag(NaturalistTags.Biomes.HAS_GIRAFFE)
                 .addTag(BiomeTags.IS_SAVANNA)
                 .addOptionalTag(Tags.Biomes.IS_SAVANNA)
-                .addOptional(bop("scrubland"));
+                .addOptional(bop("scrubland"))
+                .addOptional(terralith("ashen_savanna"))
+                .addOptional(terralith("savanna_badlands"))
+                .addOptional(terralith("savanna_slopes"));
 
         tag(NaturalistTags.Biomes.HAS_HIPPO)
                 .addTag(BiomeTags.IS_SAVANNA).addTag(BiomeTags.IS_JUNGLE)
                 .addOptionalTag(Tags.Biomes.IS_SAVANNA).addOptionalTag(Tags.Biomes.IS_JUNGLE)
-                .addOptionalTag(ATMOSPHERIC_IS_RAINFOREST);
+                .addOptionalTag(ATMOSPHERIC_IS_RAINFOREST)
+                .addOptional(terralith("amethyst_rainforest"))
+                .addOptional(terralith("orchid_swamp"))
+                .addOptional(terralith("rocky_jungle"))
+                .addOptional(terralith("tropical_jungle"))
+                .addOptional(terralith("warm_river"));
 
         tag(NaturalistTags.Biomes.HAS_LION)
                 .addTag(BiomeTags.IS_SAVANNA)
                 .addOptionalTag(Tags.Biomes.IS_SAVANNA)
-                .addOptional(bop("scrubland"));
+                .addOptional(bop("scrubland"))
+                .addOptional(terralith("ashen_savanna"))
+                .addOptional(terralith("savanna_badlands"))
+                .addOptional(terralith("savanna_slopes"));
 
         tag(NaturalistTags.Biomes.HAS_LIZARD)
                 .add(Biomes.SWAMP).add(Biomes.MANGROVE_SWAMP).add(Biomes.DESERT)
@@ -174,19 +333,48 @@ public class NaturalistBiomeTagsProvider extends TagsProvider<Biome> {
                 .addOptionalTag(Tags.Biomes.IS_SWAMP).addOptionalTag(Tags.Biomes.IS_DESERT)
                 .addOptionalTag(Tags.Biomes.IS_FOREST).addOptionalTag(Tags.Biomes.IS_SAVANNA)
                 .addOptionalTag(Tags.Biomes.IS_JUNGLE)
-                .addOptional(bop("field")).addOptional(bop("rainforest"));
+                .addOptional(bop("field")).addOptional(bop("rainforest"))
+                .addOptional(terralith("amethyst_rainforest"))
+                .addOptional(terralith("brushland"))
+                .addOptional(terralith("desert_canyon"))
+                .addOptional(terralith("desert_oasis"))
+                .addOptional(terralith("desert_spires"))
+                .addOptional(terralith("hot_shrubland"))
+                .addOptional(terralith("jungle_mountains"))
+                .addOptional(terralith("lush_desert"))
+                .addOptional(terralith("rocky_jungle"))
+                .addOptional(terralith("savanna_badlands"))
+                .addOptional(terralith("savanna_slopes"))
+                .addOptional(terralith("shrubland"))
+                .addOptional(terralith("tropical_jungle"))
+                .addOptional(terralith("warped_mesa"));
 
         tag(NaturalistTags.Biomes.HAS_RATTLESNAKE)
                 .addTag(BiomeTags.IS_BADLANDS).addTag(BiomeTags.IS_SAVANNA)
                 .add(Biomes.DESERT)
                 .addOptionalTag(Tags.Biomes.IS_SANDY).addOptionalTag(Tags.Biomes.IS_SAVANNA).addOptionalTag(Tags.Biomes.IS_DESERT)
                 .addOptional(bop("lush_desert"))
-                .addOptional(bop("scrubland"));
+                .addOptional(bop("scrubland"))
+                .addOptional(terralith("ancient_sands"))
+                .addOptional(terralith("desert_canyon"))
+                .addOptional(terralith("desert_oasis"))
+                .addOptional(terralith("desert_spires"))
+                .addOptional(terralith("gravel_desert"))
+                .addOptional(terralith("hot_shrubland"))
+                .addOptional(terralith("lush_desert"))
+                .addOptional(terralith("painted_mountains"))
+                .addOptional(terralith("red_oasis"))
+                .addOptional(terralith("savanna_badlands"))
+                .addOptional(terralith("savanna_slopes"))
+                .addOptional(terralith("warped_mesa"));
 
         tag(NaturalistTags.Biomes.HAS_RHINO)
                 .addTag(BiomeTags.IS_SAVANNA)
                 .addOptionalTag(Tags.Biomes.IS_SAVANNA)
-                .addOptional(bop("scrubland"));
+                .addOptional(bop("scrubland"))
+                .addOptional(terralith("ashen_savanna"))
+                .addOptional(terralith("savanna_badlands"))
+                .addOptional(terralith("savanna_slopes"));
 
         tag(NaturalistTags.Biomes.HAS_ROBIN)
                 .addTag(BiomeTags.IS_FOREST).addTag(BiomeTags.IS_MOUNTAIN)
@@ -194,7 +382,19 @@ public class NaturalistBiomeTagsProvider extends TagsProvider<Biome> {
                 .addOptionalTag(Tags.Biomes.IS_FOREST).addOptionalTag(Tags.Biomes.IS_MOUNTAIN).addOptionalTag(Tags.Biomes.IS_PLAINS)
                 .addOptional(bop("field")).addOptional(bop("orchard"))
                 .addOptional(bop("overgrown_greens")).addOptional(bop("pasture"))
-                .addOptional(bop("pumpkin_patch")).addOptional(bop("seasonal_forest"));
+                .addOptional(bop("pumpkin_patch")).addOptional(bop("seasonal_forest"))
+                .addOptional(terralith("blooming_plateau"))
+                .addOptional(terralith("blooming_valley"))
+                .addOptional(terralith("cloud_forest"))
+                .addOptional(terralith("forested_highlands"))
+                .addOptional(terralith("lavender_forest"))
+                .addOptional(terralith("lavender_valley"))
+                .addOptional(terralith("moonlight_grove"))
+                .addOptional(terralith("moonlight_valley"))
+                .addOptional(terralith("sakura_grove"))
+                .addOptional(terralith("sakura_valley"))
+                .addOptional(terralith("temperate_highlands"))
+                .addOptional(terralith("white_cliffs"));
 
         tag(NaturalistTags.Biomes.HAS_SNAIL)
                 .addTag(BiomeTags.IS_FOREST).addTag(BiomeTags.IS_SAVANNA)
@@ -207,20 +407,59 @@ public class NaturalistBiomeTagsProvider extends TagsProvider<Biome> {
                 .addOptionalTag(Tags.Biomes.IS_SWAMP).addOptionalTag(Tags.Biomes.IS_UNDERGROUND).addOptionalTag(Tags.Biomes.IS_MUSHROOM)
                 .addOptional(bop("bayou")).addOptional(bop("bog"))
                 .addOptional(bop("orchard")).addOptional(bop("wetland"))
-                .addOptional(bop("woodland"));
+                .addOptional(bop("woodland"))
+                .addOptional(terralith("alpine_grove"))
+                .addOptional(terralith("blooming_valley"))
+                .addOptional(terralith("brushland"))
+                .addOptional(terralith("cloud_forest"))
+                .addOptional(terralith("forested_highlands"))
+                .addOptional(terralith("ice_marsh"))
+                .addOptional(terralith("lavender_forest"))
+                .addOptional(terralith("lavender_valley"))
+                .addOptional(terralith("moonlight_grove"))
+                .addOptional(terralith("moonlight_valley"))
+                .addOptional(terralith("orchid_swamp"))
+                .addOptional(terralith("sakura_grove"))
+                .addOptional(terralith("sakura_valley"))
+                .addOptional(terralith("shrubland"))
+                .addOptional(terralith("temperate_highlands"))
+                .addOptional(terralith("warm_river"))
+                .addOptional(terralith("wintry_forest"))
+                .addOptional(terralith("yellowstone"));
 
         tag(NaturalistTags.Biomes.HAS_SNAKE)
                 .addTag(BiomeTags.IS_FOREST)
                 .add(Biomes.PLAINS).add(Biomes.SWAMP).add(Biomes.MANGROVE_SWAMP)
                 .addOptionalTag(Tags.Biomes.IS_FOREST).addOptionalTag(Tags.Biomes.IS_PLAINS).addOptionalTag(Tags.Biomes.IS_SWAMP)
                 .addOptional(bop("bayou")).addOptional(bop("bog"))
-                .addOptional(bop("wetland")).addOptional(bop("lavender_field"));
+                .addOptional(bop("wetland")).addOptional(bop("lavender_field"))
+                .addOptional(terralith("blooming_plateau"))
+                .addOptional(terralith("blooming_valley"))
+                .addOptional(terralith("brushland"))
+                .addOptional(terralith("forested_highlands"))
+                .addOptional(terralith("hot_shrubland"))
+                .addOptional(terralith("lavender_forest"))
+                .addOptional(terralith("lavender_valley"))
+                .addOptional(terralith("moonlight_grove"))
+                .addOptional(terralith("moonlight_valley"))
+                .addOptional(terralith("orchid_swamp"))
+                .addOptional(terralith("sakura_grove"))
+                .addOptional(terralith("sakura_valley"))
+                .addOptional(terralith("shrubland"))
+                .addOptional(terralith("warm_river"));
 
         tag(NaturalistTags.Biomes.HAS_SPARROW)
                 .add(Biomes.PLAINS).add(Biomes.CHERRY_GROVE)
                 .addOptionalTag(Tags.Biomes.IS_PLAINS)
                 .addOptional(bop("mystic_grove")).addOptional(bop("prairie"))
-                .addOptional(bop("rocky_shrubland")).addOptional(bop("shrubland"));
+                .addOptional(bop("rocky_shrubland")).addOptional(bop("shrubland"))
+                .addOptional(terralith("blooming_plateau"))
+                .addOptional(terralith("blooming_valley"))
+                .addOptional(terralith("brushland"))
+                .addOptional(terralith("cold_shrubland"))
+                .addOptional(terralith("lavender_valley"))
+                .addOptional(terralith("sakura_valley"))
+                .addOptional(terralith("shrubland"));
 
         tag(NaturalistTags.Biomes.HAS_TORTOISE)
                 .add(Biomes.SWAMP).add(Biomes.MANGROVE_SWAMP).add(Biomes.DESERT)
@@ -228,7 +467,14 @@ public class NaturalistBiomeTagsProvider extends TagsProvider<Biome> {
                 .addOptionalTag(Tags.Biomes.IS_SWAMP).addOptionalTag(Tags.Biomes.IS_DESERT)
                 .addOptionalTag(Tags.Biomes.IS_JUNGLE)
                 .addOptional(bop("lush_desert")).addOptional(bop("rainforest"))
-                .addOptional(bop("bayou"));
+                .addOptional(bop("bayou"))
+                .addOptional(terralith("amethyst_rainforest"))
+                .addOptional(terralith("desert_oasis"))
+                .addOptional(terralith("lush_desert"))
+                .addOptional(terralith("orchid_swamp"))
+                .addOptional(terralith("red_oasis"))
+                .addOptional(terralith("rocky_jungle"))
+                .addOptional(terralith("tropical_jungle"));
 
         tag(NaturalistTags.Biomes.HAS_VULTURE)
                 .addTag(BiomeTags.IS_SAVANNA).addTag(BiomeTags.IS_BADLANDS)
@@ -236,12 +482,27 @@ public class NaturalistBiomeTagsProvider extends TagsProvider<Biome> {
                 .addOptionalTag(Tags.Biomes.IS_SAVANNA).addOptionalTag(Tags.Biomes.IS_DESERT)
                 .addOptional(bop("dryland")).addOptional(bop("highland"))
                 .addOptional(bop("lush_desert")).addOptional(bop("lush_savanna"))
-                .addOptional(bop("scrubland"));
+                .addOptional(bop("scrubland"))
+                .addOptional(terralith("ancient_sands"))
+                .addOptional(terralith("ashen_savanna"))
+                .addOptional(terralith("bryce_canyon"))
+                .addOptional(terralith("desert_canyon"))
+                .addOptional(terralith("desert_spires"))
+                .addOptional(terralith("gravel_desert"))
+                .addOptional(terralith("hot_shrubland"))
+                .addOptional(terralith("lush_desert"))
+                .addOptional(terralith("painted_mountains"))
+                .addOptional(terralith("savanna_badlands"))
+                .addOptional(terralith("savanna_slopes"))
+                .addOptional(terralith("warped_mesa"));
 
         tag(NaturalistTags.Biomes.HAS_ZEBRA)
                 .addTag(BiomeTags.IS_SAVANNA)
                 .addOptionalTag(Tags.Biomes.IS_SAVANNA)
-                .addOptional(bop("scrubland"));
+                .addOptional(bop("scrubland"))
+                .addOptional(terralith("ashen_savanna"))
+                .addOptional(terralith("savanna_badlands"))
+                .addOptional(terralith("savanna_slopes"));
 
         coldBlacklist(NaturalistTags.Biomes.BLACKLIST_ALLIGATOR);
         emptyBlacklist(NaturalistTags.Biomes.BLACKLIST_BASS);


### PR DESCRIPTION
This PR integrates Terralith biome compatibility directly into Naturalist’s
biome spawn tag datagen, following the same pattern used for Biomes O’ Plenty.

Naturalist mobs now spawn in Terralith biomes where ecosystem alignment matches
their vanilla/BOP equivalents (wetlands, savannas, deserts, forests, jungles,
mountains, rivers, etc.), removing the need for external compatibility datapacks.

Compatibility remains additive and optional:
- does not modify vanilla spawn logic
- preserves existing BOP support
- safe for modpacks without Terralith installed