### PR TITLE
Port Naturalist to Fabric 1.20.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ subprojects {
         minecraft "net.minecraft:minecraft:$rootProject.minecraft_version"
         mappings loom.layered() {
             officialMojangMappings()
-            parchment("org.parchmentmc.data:parchment-1.20.1:${rootProject.parchment_version}")
+            parchment("org.parchmentmc.data:parchment-${rootProject.minecraft_version}:${rootProject.parchment_version}")
         }
     }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -25,11 +25,11 @@ repositories {
 dependencies {
     minecraft "net.minecraft:minecraft:$rootProject.minecraft_version"
     modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
-    modImplementation ("software.bernie.geckolib:geckolib-fabric-1.20.1:${rootProject.geckolib_version}")
+    modImplementation ("software.bernie.geckolib:geckolib-fabric-${rootProject.minecraft_version}:${rootProject.geckolib_version}")
     modImplementation ("maven.modrinth:midnightlib:${project.midnightlib_fabric_version}-fabric")
 
     mappings loom.layered {
         it.officialMojangMappings()
-        it.parchment("org.parchmentmc.data:parchment-1.20.1:${rootProject.parchment_version}")
+        it.parchment("org.parchmentmc.data:parchment-${rootProject.minecraft_version}:${rootProject.parchment_version}")
     }
 }

--- a/common/src/main/java/com/starfish_studios/naturalist/Naturalist.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/Naturalist.java
@@ -6,10 +6,10 @@ import com.starfish_studios.naturalist.core.platform.CommonPlatformHelper;
 import com.starfish_studios.naturalist.core.registry.*;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.BlockSource;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Position;
 import net.minecraft.core.dispenser.AbstractProjectileDispenseBehavior;
+import net.minecraft.core.dispenser.BlockSource;
 import net.minecraft.core.dispenser.DefaultDispenseItemBehavior;
 import net.minecraft.core.dispenser.DispenseItemBehavior;
 import net.minecraft.server.level.ServerLevel;
@@ -57,8 +57,8 @@ public class Naturalist {
 
             public @NotNull ItemStack execute(@NotNull BlockSource source, ItemStack stack) {
                 DispensibleContainerItem dispensibleContainerItem = (DispensibleContainerItem)stack.getItem();
-                BlockPos blockPos = source.getPos().relative(source.getBlockState().getValue(DispenserBlock.FACING));
-                Level level = source.getLevel();
+                BlockPos blockPos = source.pos().relative(source.state().getValue(DispenserBlock.FACING));
+                Level level = source.level();
                 if (dispensibleContainerItem.emptyContents(null, level, blockPos, null)) {
                     dispensibleContainerItem.checkExtraContent(null, level, stack, blockPos);
                     return new ItemStack(Items.BUCKET);
@@ -74,9 +74,9 @@ public class Naturalist {
 
         DispenserBlock.registerBehavior(NaturalistRegistry.SNAIL_BUCKET.get(), new DefaultDispenseItemBehavior() {
             public @NotNull ItemStack execute(@NotNull BlockSource source, ItemStack stack) {
-                Direction direction = source.getBlockState().getValue(DispenserBlock.FACING);
-                BlockPos blockPos = source.getPos().relative(direction);
-                ServerLevel serverLevel = source.getLevel();
+                Direction direction = source.state().getValue(DispenserBlock.FACING);
+                BlockPos blockPos = source.pos().relative(direction);
+                ServerLevel serverLevel = source.level();
                 Snail snail = NaturalistEntityTypes.SNAIL.get().spawn(serverLevel, stack, null, blockPos, MobSpawnType.DISPENSER, true, false);
                 if (snail != null) {
                     snail.setSnailColor(Snail.Color.getTypeById(stack.getOrCreateTag().getInt("Color")));
@@ -88,9 +88,9 @@ public class Naturalist {
         });
         DispenserBlock.registerBehavior(NaturalistRegistry.BUTTERFLY.get(), new DefaultDispenseItemBehavior() {
             public @NotNull ItemStack execute(BlockSource source, ItemStack stack) {
-                Direction direction = source.getBlockState().getValue(DispenserBlock.FACING);
-                BlockPos blockPos = source.getPos().relative(direction);
-                ServerLevel serverLevel = source.getLevel();
+                Direction direction = source.state().getValue(DispenserBlock.FACING);
+                BlockPos blockPos = source.pos().relative(direction);
+                ServerLevel serverLevel = source.level();
                 Butterfly butterfly = NaturalistEntityTypes.BUTTERFLY.get().spawn(serverLevel, stack, null, blockPos, MobSpawnType.DISPENSER, true, false);
                 if (butterfly != null) {
                     butterfly.setVariant(Butterfly.Variant.getTypeById(stack.getOrCreateTag().getInt("Variant")));

--- a/common/src/main/java/com/starfish_studios/naturalist/common/advancements/NaturalistCriteriaTriggers.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/advancements/NaturalistCriteriaTriggers.java
@@ -11,16 +11,17 @@ import java.util.Map;
 
 public class NaturalistCriteriaTriggers {
     private static final Map<ResourceLocation, CriterionTrigger<?>> CRITERIA = Maps.newHashMap();
-    public static final CaughtEntityTrigger CAUGHT_ENTITY = register(new CaughtEntityTrigger());
+    public static final ResourceLocation CAUGHT_ENTITY_ID = new ResourceLocation("naturalist", "caught_entity");
+    public static final CaughtEntityTrigger CAUGHT_ENTITY = register(CAUGHT_ENTITY_ID, new CaughtEntityTrigger());
 
     public void CriteriaTriggers() {
     }
 
-    public static <T extends CriterionTrigger<?>> @NotNull T register(T criterion) {
-        if (CRITERIA.containsKey(criterion.getId())) {
-            throw new IllegalArgumentException("Duplicate criterion id " + criterion.getId());
+    public static <T extends CriterionTrigger<?>> @NotNull T register(ResourceLocation id, T criterion) {
+        if (CRITERIA.containsKey(id)) {
+            throw new IllegalArgumentException("Duplicate criterion id " + id);
         } else {
-            CRITERIA.put(criterion.getId(), criterion);
+            CRITERIA.put(id, criterion);
             return criterion;
         }
     }

--- a/common/src/main/java/com/starfish_studios/naturalist/common/advancements/criterion/CaughtEntityTrigger.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/advancements/criterion/CaughtEntityTrigger.java
@@ -1,60 +1,39 @@
-//
-// Source code recreated from a .class file by IntelliJ IDEA
-// (powered by FernFlower decompiler)
-//
-
 package com.starfish_studios.naturalist.common.advancements.criterion;
 
-import com.google.gson.JsonObject;
-import net.minecraft.advancements.critereon.*;
-import net.minecraft.resources.ResourceLocation;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.advancements.critereon.ContextAwarePredicate;
+import net.minecraft.advancements.critereon.EntityPredicate;
+import net.minecraft.advancements.critereon.ItemPredicate;
+import net.minecraft.advancements.critereon.SimpleCriterionTrigger;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.ExtraCodecs;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Optional;
+
 public class CaughtEntityTrigger extends SimpleCriterionTrigger<CaughtEntityTrigger.TriggerInstance> {
-    static final ResourceLocation ID = new ResourceLocation("caught_entity");
-
-    public CaughtEntityTrigger() {
-    }
-
-    public @NotNull ResourceLocation getId() {
-        return ID;
-    }
-
-    public @NotNull TriggerInstance createInstance(JsonObject json, ContextAwarePredicate entityPredicate, DeserializationContext conditionsParser) {
-        ItemPredicate itemPredicate = ItemPredicate.fromJson(json.get("item"));
-        return new TriggerInstance(entityPredicate, itemPredicate);
+    @Override
+    public @NotNull Codec<TriggerInstance> codec() {
+        return TriggerInstance.CODEC;
     }
 
     public void trigger(ServerPlayer player, ItemStack stack) {
-        this.trigger(player, (triggerInstance) -> {
-            return triggerInstance.matches(stack);
-        });
+        this.trigger(player, triggerInstance -> triggerInstance.matches(stack));
     }
 
-    public static class TriggerInstance extends AbstractCriterionTriggerInstance {
-        private final ItemPredicate item;
-
-        public TriggerInstance(ContextAwarePredicate composite, ItemPredicate itemPredicate) {
-            super(CaughtEntityTrigger.ID, composite);
-            this.item = itemPredicate;
-        }
-
-        /*
-        public static TriggerInstance caughtMob(ItemPredicate item) {
-            return new TriggerInstance(Composite.ANY, item);
-        }
-        */
+    public record TriggerInstance(
+        Optional<ContextAwarePredicate> player,
+        Optional<ItemPredicate> item
+    ) implements SimpleCriterionTrigger.SimpleInstance {
+        public static final Codec<TriggerInstance> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            ExtraCodecs.strictOptionalField(EntityPredicate.ADVANCEMENT_CODEC, "player").forGetter(TriggerInstance::player),
+            ExtraCodecs.strictOptionalField(ItemPredicate.CODEC, "item").forGetter(TriggerInstance::item)
+        ).apply(instance, TriggerInstance::new));
 
         public boolean matches(ItemStack stack) {
-            return this.item.matches(stack);
-        }
-
-        public @NotNull JsonObject serializeToJson(@NotNull SerializationContext context) {
-            JsonObject jsonObject = super.serializeToJson(context);
-            jsonObject.add("item", this.item.serializeToJson());
-            return jsonObject;
+            return item.map(predicate -> predicate.matches(stack)).orElse(true);
         }
     }
 }

--- a/common/src/main/java/com/starfish_studios/naturalist/common/block/CattailBlock.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/block/CattailBlock.java
@@ -44,7 +44,7 @@ public class CattailBlock extends DoublePlantBlock implements SimpleWaterloggedB
         this.registerDefaultState(this.stateDefinition.any().setValue(HALF, DoubleBlockHalf.LOWER).setValue(WATERLOGGED, false));
     }
 
-    public boolean isValidBonemealTarget(LevelReader level, BlockPos pos, BlockState state, boolean isClient) {
+    public boolean isValidBonemealTarget(LevelReader level, BlockPos pos, BlockState state) {
         return true;
     }
 

--- a/common/src/main/java/com/starfish_studios/naturalist/common/block/ChrysalisBlock.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/block/ChrysalisBlock.java
@@ -1,5 +1,6 @@
 package com.starfish_studios.naturalist.common.block;
 
+import com.mojang.serialization.MapCodec;
 import com.starfish_studios.naturalist.common.entity.Butterfly;
 import com.starfish_studios.naturalist.core.registry.NaturalistEntityTypes;
 import net.minecraft.core.BlockPos;
@@ -27,6 +28,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class ChrysalisBlock extends HorizontalDirectionalBlock {
+    public static final MapCodec<ChrysalisBlock> CODEC = simpleCodec(ChrysalisBlock::new);
     public static final IntegerProperty AGE = BlockStateProperties.AGE_3;
     protected static final VoxelShape[] EAST_AABB = new VoxelShape[]{Block.box(11.0D, 7.0D, 6.0D, 15.0D, 12.0D, 10.0D), Block.box(9.0D, 5.0D, 5.0D, 15.0D, 12.0D, 11.0D), Block.box(7.0D, 3.0D, 4.0D, 15.0D, 12.0D, 12.0D), Block.box(7.0D, 3.0D, 4.0D, 15.0D, 12.0D, 12.0D)};
     protected static final VoxelShape[] WEST_AABB = new VoxelShape[]{Block.box(1.0D, 7.0D, 6.0D, 5.0D, 12.0D, 10.0D), Block.box(1.0D, 5.0D, 5.0D, 7.0D, 12.0D, 11.0D), Block.box(1.0D, 3.0D, 4.0D, 9.0D, 12.0D, 12.0D), Block.box(1.0D, 3.0D, 4.0D, 9.0D, 12.0D, 12.0D)};
@@ -36,6 +38,11 @@ public class ChrysalisBlock extends HorizontalDirectionalBlock {
     public ChrysalisBlock(Properties properties) {
         super(properties);
         this.registerDefaultState(this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(AGE, 0));
+    }
+
+    @Override
+    protected MapCodec<? extends ChrysalisBlock> codec() {
+        return CODEC;
     }
 
     @Override

--- a/common/src/main/java/com/starfish_studios/naturalist/common/block/GlowGoopBlock.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/block/GlowGoopBlock.java
@@ -10,6 +10,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.SimpleWaterloggedBlock;
@@ -62,7 +63,7 @@ public class GlowGoopBlock extends Block implements SimpleWaterloggedBlock {
     }
 
     @Override
-    public @NotNull ItemStack getCloneItemStack(BlockGetter level, BlockPos pos, BlockState state) {
+    public @NotNull ItemStack getCloneItemStack(LevelReader level, BlockPos pos, BlockState state) {
         return NaturalistRegistry.GLOW_GOOP.get().asItem().getDefaultInstance();
     }
 

--- a/common/src/main/java/com/starfish_studios/naturalist/common/block/TeddyBearBlock.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/block/TeddyBearBlock.java
@@ -1,5 +1,6 @@
 package com.starfish_studios.naturalist.common.block;
 
+import com.mojang.serialization.MapCodec;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.context.BlockPlaceContext;
@@ -12,11 +13,17 @@ import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
 public class TeddyBearBlock extends HorizontalDirectionalBlock {
+    public static final MapCodec<TeddyBearBlock> CODEC = simpleCodec(TeddyBearBlock::new);
     private static final VoxelShape X_AXIS_AABB = Block.box(3, 0, 2, 13, 15, 14);
     private static final VoxelShape Z_AXIS_AABB = Block.box(2, 0, 3, 14, 15, 13);
 
     public TeddyBearBlock(Properties properties) {
         super(properties);
+    }
+
+    @Override
+    protected MapCodec<? extends TeddyBearBlock> codec() {
+        return CODEC;
     }
 
     @Override

--- a/common/src/main/java/com/starfish_studios/naturalist/common/block/TortoiseEggBlock.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/block/TortoiseEggBlock.java
@@ -14,9 +14,9 @@ import net.minecraft.world.entity.monster.Zombie;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.TurtleEggBlock;
@@ -48,7 +48,7 @@ public class TortoiseEggBlock extends TurtleEggBlock {
     }
 
     @Override
-    public @NotNull ItemStack getCloneItemStack(@NotNull BlockGetter level, @NotNull BlockPos pos, @NotNull BlockState state) {
+    public @NotNull ItemStack getCloneItemStack(@NotNull LevelReader level, @NotNull BlockPos pos, @NotNull BlockState state) {
         ItemStack stack = super.getCloneItemStack(level, pos, state);
         stack.getOrCreateTag().putInt("Variant", state.getValue(VARIANT));
         return stack;

--- a/common/src/main/java/com/starfish_studios/naturalist/common/entity/Alligator.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/entity/Alligator.java
@@ -166,11 +166,6 @@ public class Alligator extends NaturalistAnimal implements NaturalistGeoEntity, 
         return 40;
     }
 
-    @Override
-    public boolean canBreatheUnderwater() {
-        return true;
-    }
-
     // region DATA
 
     @Override

--- a/common/src/main/java/com/starfish_studios/naturalist/common/entity/Bear.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/entity/Bear.java
@@ -399,7 +399,7 @@ public class Bear extends NaturalistAnimal implements NeutralMob, NaturalistGeoE
         if (!this.getMainHandItem().isEmpty() && !this.level().isClientSide) {
             ItemEntity itemEntity = new ItemEntity(this.level(), this.getX() + this.getLookAngle().x, this.getY() + 1.0D, this.getZ() + this.getLookAngle().z, this.getMainHandItem());
             itemEntity.setPickUpDelay(80);
-            itemEntity.setThrower(this.getUUID());
+            itemEntity.setThrower(this);
             this.playSound(NaturalistSoundEvents.BEAR_SPIT.get(), 1.0F, 1.0F);
             this.level().addFreshEntity(itemEntity);
             this.setItemSlot(EquipmentSlot.MAINHAND, ItemStack.EMPTY);
@@ -856,8 +856,14 @@ public class Bear extends NaturalistAnimal implements NeutralMob, NaturalistGeoE
         }
 
         @Override
-        protected double getAttackReachSqr(LivingEntity pAttackTarget) {
-            return pAttackTarget instanceof AbstractSchoolingFish ? super.getAttackReachSqr(pAttackTarget) : 4.0F + pAttackTarget.getBbWidth();
+        protected boolean canPerformAttack(LivingEntity attackTarget) {
+            if (attackTarget instanceof AbstractSchoolingFish) {
+                return super.canPerformAttack(attackTarget);
+            }
+            double reach = 4.0F + attackTarget.getBbWidth();
+            return this.isTimeToAttack()
+                && this.mob.distanceToSqr(attackTarget) <= reach
+                && this.mob.getSensing().hasLineOfSight(attackTarget);
         }
     }
 }

--- a/common/src/main/java/com/starfish_studios/naturalist/common/entity/Elephant.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/entity/Elephant.java
@@ -305,8 +305,10 @@ public class Elephant extends NaturalistAnimal implements NeutralMob, Naturalist
         }
 
         @Override
-        protected double getAttackReachSqr(LivingEntity attackTarget) {
-            return Mth.square(this.mob.getBbWidth());
+        protected boolean canPerformAttack(LivingEntity attackTarget) {
+            return this.isTimeToAttack()
+                && this.mob.distanceToSqr(attackTarget) <= Mth.square(this.mob.getBbWidth())
+                && this.mob.getSensing().hasLineOfSight(attackTarget);
         }
     }
 

--- a/common/src/main/java/com/starfish_studios/naturalist/common/entity/Firefly.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/entity/Firefly.java
@@ -268,7 +268,7 @@ public class Firefly extends NaturalistAnimal implements FlyingAnimal, Naturalis
 
         @Override
         protected boolean isValidTarget(LevelReader pLevel, BlockPos pPos) {
-            return pLevel.getBlockState(pPos).is(Blocks.GRASS) || pLevel.getBlockState(pPos).is(Blocks.FERN) || pLevel.getBlockState(pPos).is(Blocks.TALL_GRASS);
+            return pLevel.getBlockState(pPos).is(Blocks.SHORT_GRASS) || pLevel.getBlockState(pPos).is(Blocks.FERN) || pLevel.getBlockState(pPos).is(Blocks.TALL_GRASS);
         }
 
         @Override
@@ -277,7 +277,7 @@ public class Firefly extends NaturalistAnimal implements FlyingAnimal, Naturalis
             Level level = firefly.level();
             if (this.isReachedTarget()) {
                 if (!level.isClientSide) {
-                    ((ServerLevel)level).sendParticles(new BlockParticleOption(ParticleTypes.BLOCK, Blocks.GRASS.defaultBlockState()), firefly.getX(), firefly.getY(), firefly.getZ(), 50, firefly.getBbWidth() / 4.0F, firefly.getBbHeight() / 4.0F, firefly.getBbWidth() / 4.0F, 0.05D);
+                    ((ServerLevel)level).sendParticles(new BlockParticleOption(ParticleTypes.BLOCK, Blocks.SHORT_GRASS.defaultBlockState()), firefly.getX(), firefly.getY(), firefly.getZ(), 50, firefly.getBbWidth() / 4.0F, firefly.getBbHeight() / 4.0F, firefly.getBbWidth() / 4.0F, 0.05D);
                 }
                 level.playSound(null, firefly.blockPosition(), NaturalistSoundEvents.FIREFLY_HIDE.get(), SoundSource.NEUTRAL, 0.7F, 0.9F + level.random.nextFloat() * 0.2F);
                 firefly.discard();

--- a/common/src/main/java/com/starfish_studios/naturalist/common/entity/Giraffe.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/entity/Giraffe.java
@@ -314,16 +314,11 @@ public class Giraffe extends NaturalistAnimal implements NaturalistGeoEntity {
             this.yBodyRot = mob.yBodyRot;
         }
 
-        callback.accept(passenger, this.getX(), this.getY() + this.getPassengersRidingOffset() + passenger.getMyRidingOffset(), this.getZ());
+        callback.accept(passenger, this.getX(), this.getY() + this.getBbHeight() * 0.6 + passenger.getMyRidingOffset(this), this.getZ());
 
         if (passenger instanceof LivingEntity livingEntity) {
             livingEntity.yBodyRot = this.yBodyRot;
         }
-    }
-
-    @Override
-    public double getPassengersRidingOffset() {
-        return this.getBbHeight() * 0.6;
     }
 
     @Override

--- a/common/src/main/java/com/starfish_studios/naturalist/common/entity/Hippo.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/entity/Hippo.java
@@ -120,11 +120,6 @@ public class Hippo extends NaturalistAnimal implements NaturalistGeoEntity {
     }
 
     @Override
-    public boolean canBreatheUnderwater() {
-        return true;
-    }
-
-    @Override
     protected void registerGoals() {
         this.goalSelector.addGoal(0, new SmoothFloatGoal(this));
         this.goalSelector.addGoal(1, new BreedGoal(this, 1.0D));

--- a/common/src/main/java/com/starfish_studios/naturalist/common/entity/Snail.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/entity/Snail.java
@@ -108,11 +108,6 @@ public class Snail extends ClimbingAnimal implements NaturalistGeoEntity, Bucket
 
 
     @Override
-    public boolean canBreatheUnderwater() {
-        return true;
-    }
-
-    @Override
     public boolean hasEgg() {
         return this.entityData.get(HAS_EGG);
     }

--- a/common/src/main/java/com/starfish_studios/naturalist/common/entity/Snake.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/entity/Snake.java
@@ -259,7 +259,7 @@ public class Snake extends ClimbingAnimal implements SleepingAnimal, NeutralMob,
         if (!this.getMainHandItem().isEmpty() && !this.level().isClientSide) {
             ItemEntity itemEntity = new ItemEntity(this.level(), this.getX() + this.getLookAngle().x, this.getY() + 1.0D, this.getZ() + this.getLookAngle().z, this.getMainHandItem());
             itemEntity.setPickUpDelay(80);
-            itemEntity.setThrower(this.getUUID());
+            itemEntity.setThrower(this);
             this.playSound(SoundEvents.FOX_SPIT, 1.0F, 1.0F);
             this.level().addFreshEntity(itemEntity);
             this.setItemSlot(EquipmentSlot.MAINHAND, ItemStack.EMPTY);
@@ -513,7 +513,7 @@ public class Snake extends ClimbingAnimal implements SleepingAnimal, NeutralMob,
                     if (this.path != null) {
                         return true;
                     } else {
-                        return this.getAttackReachSqr(livingEntity) >= this.mob.distanceToSqr(livingEntity.getX(), livingEntity.getY(), livingEntity.getZ());
+                        return this.isWithinAttackRange(livingEntity);
                     }
                 }
             }
@@ -525,8 +525,14 @@ public class Snake extends ClimbingAnimal implements SleepingAnimal, NeutralMob,
         }
 
         @Override
-        protected double getAttackReachSqr(LivingEntity pAttackTarget) {
-            return 4.0F + pAttackTarget.getBbWidth();
+        protected boolean canPerformAttack(LivingEntity attackTarget) {
+            return this.isTimeToAttack()
+                && this.isWithinAttackRange(attackTarget)
+                && this.mob.getSensing().hasLineOfSight(attackTarget);
+        }
+
+        private boolean isWithinAttackRange(LivingEntity attackTarget) {
+            return this.mob.distanceToSqr(attackTarget) <= 4.0F + attackTarget.getBbWidth();
         }
     }
 }

--- a/common/src/main/java/com/starfish_studios/naturalist/common/entity/Tortoise.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/entity/Tortoise.java
@@ -254,11 +254,6 @@ public class Tortoise extends TamableAnimal implements NaturalistGeoEntity, Hidi
         return 0.4;
     }
 
-    @Override
-    public boolean canBreatheUnderwater() {
-        return true;
-    }
-
     // ENTITY DATA
 
     public int getVariant() {

--- a/common/src/main/java/com/starfish_studios/naturalist/common/entity/Vulture.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/entity/Vulture.java
@@ -337,9 +337,8 @@ public class Vulture extends PathfinderMob implements NaturalistGeoEntity, Flyin
         }
 
         @Override
-        protected void checkAndPerformAttack(LivingEntity enemy, double distToEnemySqr) {
-            double reach = this.getAttackReachSqr(enemy);
-            if (distToEnemySqr <= reach && this.getTicksUntilNextAttack() <= 0) {
+        protected void checkAndPerformAttack(LivingEntity enemy) {
+            if (this.canPerformAttack(enemy)) {
                 this.resetAttackCooldown();
                 this.mob.swing(InteractionHand.MAIN_HAND);
                 if (!(enemy instanceof Player)) {

--- a/common/src/main/java/com/starfish_studios/naturalist/common/entity/Zebra.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/entity/Zebra.java
@@ -112,11 +112,6 @@ public class Zebra extends AbstractChestedHorse {
     }
 
     @Override
-    public double getPassengersRidingOffset() {
-        return super.getPassengersRidingOffset() + 0;
-    }
-
-    @Override
     protected void playJumpSound() {
         this.playSound(NaturalistSoundEvents.ZEBRA_JUMP.get(), 0.4F, 1.0F);
     }

--- a/common/src/main/java/com/starfish_studios/naturalist/common/entity/core/TamableNaturalistAnimal.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/entity/core/TamableNaturalistAnimal.java
@@ -20,7 +20,7 @@ import net.minecraft.world.entity.OwnableEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.scores.Team;
+import net.minecraft.world.scores.PlayerTeam;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class TamableNaturalistAnimal extends NaturalistAnimal implements OwnableEntity {
@@ -163,7 +163,7 @@ public abstract class TamableNaturalistAnimal extends NaturalistAnimal implement
         return true;
     }
 
-    public Team getTeam() {
+    public PlayerTeam getTeam() {
         if (this.isTame()) {
             LivingEntity livingEntity = this.getOwner();
             if (livingEntity != null) {

--- a/common/src/main/java/com/starfish_studios/naturalist/common/entity/core/ai/goal/CloseMeleeAttackGoal.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/entity/core/ai/goal/CloseMeleeAttackGoal.java
@@ -11,7 +11,9 @@ public class CloseMeleeAttackGoal extends MeleeAttackGoal {
     }
 
     @Override
-    protected double getAttackReachSqr(LivingEntity pAttackTarget) {
-        return Mth.square(this.mob.getBbWidth() * 1.2f);
+    protected boolean canPerformAttack(LivingEntity attackTarget) {
+        return this.isTimeToAttack()
+            && this.mob.distanceToSqr(attackTarget) <= Mth.square(this.mob.getBbWidth() * 1.2f)
+            && this.mob.getSensing().hasLineOfSight(attackTarget);
     }
 }

--- a/common/src/main/java/com/starfish_studios/naturalist/common/item/BugNetItem.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/item/BugNetItem.java
@@ -24,7 +24,8 @@ public class BugNetItem extends Item {
         var recipeManager = player.level().getRecipeManager();
         Optional<BugNetInteractionRecipe> allRecipes = recipeManager.getAllRecipesFor(NaturalistRecipes.BUG_NET)
                 .stream()
-                .filter(r -> r.entityType() == interactionTarget.getType())
+                .map(recipe -> recipe.value())
+                .filter(recipe -> recipe.entityType() == interactionTarget.getType())
                 .findFirst();
 
         if (allRecipes.isPresent()) {

--- a/common/src/main/java/com/starfish_studios/naturalist/common/recipe/BugNetInteractionRecipe.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/common/recipe/BugNetInteractionRecipe.java
@@ -1,24 +1,21 @@
 package com.starfish_studios.naturalist.common.recipe;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonSyntaxException;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.starfish_studios.naturalist.core.registry.NaturalistRecipes;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.GsonHelper;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.RecipeType;
-import net.minecraft.world.item.crafting.ShapedRecipe;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 
-public record BugNetInteractionRecipe(ResourceLocation id, EntityType<?> entityType, ItemStack dropStack) implements Recipe<Container> {
+public record BugNetInteractionRecipe(EntityType<?> entityType, ItemStack dropStack) implements Recipe<Container> {
 
     @Override
     public boolean matches(Container container, Level level) {
@@ -41,11 +38,6 @@ public record BugNetInteractionRecipe(ResourceLocation id, EntityType<?> entityT
     }
 
     @Override
-    public ResourceLocation getId() {
-        return id;
-    }
-
-    @Override
     public RecipeSerializer<?> getSerializer() {
         return NaturalistRecipes.BUG_NET_SERIALIZER;
     }
@@ -56,31 +48,22 @@ public record BugNetInteractionRecipe(ResourceLocation id, EntityType<?> entityT
     }
 
     public static class Serializer implements RecipeSerializer<BugNetInteractionRecipe> {
+        private static final Codec<BugNetInteractionRecipe> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            BuiltInRegistries.ENTITY_TYPE.byNameCodec().fieldOf("entity_type").forGetter(BugNetInteractionRecipe::entityType),
+            ItemStack.ITEM_WITH_COUNT_CODEC.fieldOf("result").forGetter(BugNetInteractionRecipe::dropStack)
+        ).apply(instance, BugNetInteractionRecipe::new));
+
         @Override
-        public @NotNull BugNetInteractionRecipe fromJson(@NotNull ResourceLocation recipeId, @NotNull JsonObject serializedRecipe) {
-            JsonObject resultObject = GsonHelper.getAsJsonObject(serializedRecipe, "result");
-
-            ItemStack output = ShapedRecipe.itemStackFromJson(resultObject);
-            if (output.isEmpty()) {
-                throw new IllegalArgumentException("Invalid or empty output ItemStack for recipe " + recipeId);
-            }
-
-            String entityTypeId = GsonHelper.getAsString(serializedRecipe, "entity_type");
-            if (entityTypeId.isEmpty()) {
-                throw new JsonSyntaxException("Missing or invalid 'entity_type' in recipe: " + recipeId);
-            }
-
-            EntityType<?> entityType = BuiltInRegistries.ENTITY_TYPE.get(new ResourceLocation(entityTypeId));
-
-            return new BugNetInteractionRecipe(recipeId, entityType, output);
+        public Codec<BugNetInteractionRecipe> codec() {
+            return CODEC;
         }
 
         @Override
-        public BugNetInteractionRecipe fromNetwork(ResourceLocation recipeId, FriendlyByteBuf buffer) {
+        public BugNetInteractionRecipe fromNetwork(FriendlyByteBuf buffer) {
             ItemStack output = buffer.readItem();
             EntityType<?> entityType = BuiltInRegistries.ENTITY_TYPE.get(buffer.readResourceLocation());
 
-            return new BugNetInteractionRecipe(recipeId, entityType, output);
+            return new BugNetInteractionRecipe(entityType, output);
         }
 
         @Override

--- a/common/src/main/java/com/starfish_studios/naturalist/core/registry/NaturalistRegistry.java
+++ b/common/src/main/java/com/starfish_studios/naturalist/core/registry/NaturalistRegistry.java
@@ -64,11 +64,11 @@ public class NaturalistRegistry {
     public static final Supplier<Item> FUR = registerItem("fur", () -> new Item(new Item.Properties()));
 
     //region BLOCKS & ITEMS
-    public static final Supplier<Block> ALLIGATOR_EGG = registerBlock("alligator_egg", () -> new AlligatorEggBlock(BlockBehaviour.Properties.copy(Blocks.TURTLE_EGG)));
+    public static final Supplier<Block> ALLIGATOR_EGG = registerBlock("alligator_egg", () -> new AlligatorEggBlock(BlockBehaviour.Properties.ofFullCopy(Blocks.TURTLE_EGG)));
     public static final Supplier<Item> DUCK_EGG = registerItem("duck_egg", () -> new DuckEggItem(new Item.Properties()));
-    public static final Supplier<Block> TORTOISE_EGG = registerBlock("tortoise_egg", () -> new TortoiseEggBlock(BlockBehaviour.Properties.copy(Blocks.TURTLE_EGG)));
+    public static final Supplier<Block> TORTOISE_EGG = registerBlock("tortoise_egg", () -> new TortoiseEggBlock(BlockBehaviour.Properties.ofFullCopy(Blocks.TURTLE_EGG)));
     public static final Supplier<Item> COOKED_EGG = registerItem("cooked_egg", () -> new Item(new Item.Properties().food(Foods.BREAD)));
-    public static final Supplier<Block> SNAIL_EGGS = registerBlock("snail_eggs", () -> new SnailEggBlock(BlockBehaviour.Properties.copy(Blocks.FROGSPAWN)));
+    public static final Supplier<Block> SNAIL_EGGS = registerBlock("snail_eggs", () -> new SnailEggBlock(BlockBehaviour.Properties.ofFullCopy(Blocks.FROGSPAWN)));
 //    public static final Supplier<Block> CATTAIL = registerBlock("cattail", () -> new CattailBlock(BlockBehaviour.Properties.of().noCollission().randomTicks().instabreak().sound(SoundType.SMALL_DRIPLEAF).offsetType(BlockBehaviour.OffsetType.XZ)));
 //    public static final Supplier<Item> CATTAIL_FLUFF = registerItem("cattail_fluff", () -> new Item(new Item.Properties()));
     public static final Supplier<Item> ANTLER = registerItem("antler", () -> new Item(new Item.Properties()));
@@ -99,28 +99,28 @@ public class NaturalistRegistry {
     // endregion
 
 
-    public static final Supplier<Block> AZURE_FROGLASS = registerBlock("azure_froglass", () -> new GlassBlock(BlockBehaviour.Properties.copy(Blocks.GLASS)));
-    public static final Supplier<Block> VERDANT_FROGLASS = registerBlock("verdant_froglass", () -> new GlassBlock(BlockBehaviour.Properties.copy(Blocks.GLASS)));
-    public static final Supplier<Block> CRIMSON_FROGLASS = registerBlock("crimson_froglass", () -> new GlassBlock(BlockBehaviour.Properties.copy(Blocks.GLASS)));
-    public static final Supplier<Block> AZURE_FROGLASS_PANE = registerBlock("azure_froglass_pane", () -> new IronBarsBlock(BlockBehaviour.Properties.copy(Blocks.GLASS_PANE)));
-    public static final Supplier<Block> VERDANT_FROGLASS_PANE = registerBlock("verdant_froglass_pane", () -> new IronBarsBlock(BlockBehaviour.Properties.copy(Blocks.GLASS_PANE)));
-    public static final Supplier<Block> CRIMSON_FROGLASS_PANE = registerBlock("crimson_froglass_pane", () -> new IronBarsBlock(BlockBehaviour.Properties.copy(Blocks.GLASS_PANE)));
-    public static final Supplier<Block> SHELLSTONE = registerBlock("shellstone", () -> new Block(BlockBehaviour.Properties.copy(Blocks.SANDSTONE)));
-    public static final Supplier<Block> SHELLSTONE_STAIRS = registerBlock("shellstone_stairs", () -> new StairBlock(SHELLSTONE.get().defaultBlockState(), BlockBehaviour.Properties.copy(Blocks.SANDSTONE)));
-    public static final Supplier<Block> SHELLSTONE_SLAB = registerBlock("shellstone_slab", () -> new SlabBlock(BlockBehaviour.Properties.copy(Blocks.SANDSTONE)));
-    public static final Supplier<Block> SHELLSTONE_WALL = registerBlock("shellstone_wall", () -> new WallBlock(BlockBehaviour.Properties.copy(Blocks.SANDSTONE)));
-    public static final Supplier<Block> SHELLSTONE_BRICKS = registerBlock("shellstone_bricks", () -> new Block(BlockBehaviour.Properties.copy(Blocks.SANDSTONE)));
-    public static final Supplier<Block> SHELLSTONE_BRICK_STAIRS = registerBlock("shellstone_brick_stairs", () -> new StairBlock(SHELLSTONE_BRICKS.get().defaultBlockState(), BlockBehaviour.Properties.copy(Blocks.SANDSTONE)));
-    public static final Supplier<Block> SHELLSTONE_BRICK_SLAB = registerBlock("shellstone_brick_slab", () -> new SlabBlock(BlockBehaviour.Properties.copy(Blocks.SANDSTONE)));
-    public static final Supplier<Block> SHELLSTONE_BRICK_WALL = registerBlock("shellstone_brick_wall", () -> new WallBlock(BlockBehaviour.Properties.copy(Blocks.SANDSTONE)));
-    public static final Supplier<Block> CUT_SHELLSTONE = registerBlock("cut_shellstone", () -> new Block(BlockBehaviour.Properties.copy(Blocks.SANDSTONE)));
-    public static final Supplier<Block> CUT_SHELLSTONE_STAIRS = registerBlock("cut_shellstone_stairs", () -> new StairBlock(CUT_SHELLSTONE.get().defaultBlockState(), BlockBehaviour.Properties.copy(Blocks.SANDSTONE)));
-    public static final Supplier<Block> CUT_SHELLSTONE_SLAB = registerBlock("cut_shellstone_slab", () -> new SlabBlock(BlockBehaviour.Properties.copy(Blocks.SANDSTONE)));
-    public static final Supplier<Block> CUT_SHELLSTONE_WALL = registerBlock("cut_shellstone_wall", () -> new WallBlock(BlockBehaviour.Properties.copy(Blocks.SANDSTONE)));
-    public static final Supplier<Block> SMOOTH_SHELLSTONE = registerBlock("smooth_shellstone", () -> new Block(BlockBehaviour.Properties.copy(Blocks.SANDSTONE)));
-    public static final Supplier<Block> SMOOTH_SHELLSTONE_STAIRS = registerBlock("smooth_shellstone_stairs", () -> new StairBlock(SMOOTH_SHELLSTONE.get().defaultBlockState(), BlockBehaviour.Properties.copy(Blocks.SANDSTONE)));
-    public static final Supplier<Block> SMOOTH_SHELLSTONE_SLAB = registerBlock("smooth_shellstone_slab", () -> new SlabBlock(BlockBehaviour.Properties.copy(Blocks.SANDSTONE)));
-    public static final Supplier<Block> SMOOTH_SHELLSTONE_WALL = registerBlock("smooth_shellstone_wall", () -> new WallBlock(BlockBehaviour.Properties.copy(Blocks.SANDSTONE)));
+    public static final Supplier<Block> AZURE_FROGLASS = registerBlock("azure_froglass", () -> new StainedGlassBlock(DyeColor.LIGHT_BLUE, BlockBehaviour.Properties.ofFullCopy(Blocks.GLASS)));
+    public static final Supplier<Block> VERDANT_FROGLASS = registerBlock("verdant_froglass", () -> new StainedGlassBlock(DyeColor.GREEN, BlockBehaviour.Properties.ofFullCopy(Blocks.GLASS)));
+    public static final Supplier<Block> CRIMSON_FROGLASS = registerBlock("crimson_froglass", () -> new StainedGlassBlock(DyeColor.RED, BlockBehaviour.Properties.ofFullCopy(Blocks.GLASS)));
+    public static final Supplier<Block> AZURE_FROGLASS_PANE = registerBlock("azure_froglass_pane", () -> new IronBarsBlock(BlockBehaviour.Properties.ofFullCopy(Blocks.GLASS_PANE)));
+    public static final Supplier<Block> VERDANT_FROGLASS_PANE = registerBlock("verdant_froglass_pane", () -> new IronBarsBlock(BlockBehaviour.Properties.ofFullCopy(Blocks.GLASS_PANE)));
+    public static final Supplier<Block> CRIMSON_FROGLASS_PANE = registerBlock("crimson_froglass_pane", () -> new IronBarsBlock(BlockBehaviour.Properties.ofFullCopy(Blocks.GLASS_PANE)));
+    public static final Supplier<Block> SHELLSTONE = registerBlock("shellstone", () -> new Block(BlockBehaviour.Properties.ofFullCopy(Blocks.SANDSTONE)));
+    public static final Supplier<Block> SHELLSTONE_STAIRS = registerBlock("shellstone_stairs", () -> new StairBlock(SHELLSTONE.get().defaultBlockState(), BlockBehaviour.Properties.ofFullCopy(Blocks.SANDSTONE)));
+    public static final Supplier<Block> SHELLSTONE_SLAB = registerBlock("shellstone_slab", () -> new SlabBlock(BlockBehaviour.Properties.ofFullCopy(Blocks.SANDSTONE)));
+    public static final Supplier<Block> SHELLSTONE_WALL = registerBlock("shellstone_wall", () -> new WallBlock(BlockBehaviour.Properties.ofFullCopy(Blocks.SANDSTONE)));
+    public static final Supplier<Block> SHELLSTONE_BRICKS = registerBlock("shellstone_bricks", () -> new Block(BlockBehaviour.Properties.ofFullCopy(Blocks.SANDSTONE)));
+    public static final Supplier<Block> SHELLSTONE_BRICK_STAIRS = registerBlock("shellstone_brick_stairs", () -> new StairBlock(SHELLSTONE_BRICKS.get().defaultBlockState(), BlockBehaviour.Properties.ofFullCopy(Blocks.SANDSTONE)));
+    public static final Supplier<Block> SHELLSTONE_BRICK_SLAB = registerBlock("shellstone_brick_slab", () -> new SlabBlock(BlockBehaviour.Properties.ofFullCopy(Blocks.SANDSTONE)));
+    public static final Supplier<Block> SHELLSTONE_BRICK_WALL = registerBlock("shellstone_brick_wall", () -> new WallBlock(BlockBehaviour.Properties.ofFullCopy(Blocks.SANDSTONE)));
+    public static final Supplier<Block> CUT_SHELLSTONE = registerBlock("cut_shellstone", () -> new Block(BlockBehaviour.Properties.ofFullCopy(Blocks.SANDSTONE)));
+    public static final Supplier<Block> CUT_SHELLSTONE_STAIRS = registerBlock("cut_shellstone_stairs", () -> new StairBlock(CUT_SHELLSTONE.get().defaultBlockState(), BlockBehaviour.Properties.ofFullCopy(Blocks.SANDSTONE)));
+    public static final Supplier<Block> CUT_SHELLSTONE_SLAB = registerBlock("cut_shellstone_slab", () -> new SlabBlock(BlockBehaviour.Properties.ofFullCopy(Blocks.SANDSTONE)));
+    public static final Supplier<Block> CUT_SHELLSTONE_WALL = registerBlock("cut_shellstone_wall", () -> new WallBlock(BlockBehaviour.Properties.ofFullCopy(Blocks.SANDSTONE)));
+    public static final Supplier<Block> SMOOTH_SHELLSTONE = registerBlock("smooth_shellstone", () -> new Block(BlockBehaviour.Properties.ofFullCopy(Blocks.SANDSTONE)));
+    public static final Supplier<Block> SMOOTH_SHELLSTONE_STAIRS = registerBlock("smooth_shellstone_stairs", () -> new StairBlock(SMOOTH_SHELLSTONE.get().defaultBlockState(), BlockBehaviour.Properties.ofFullCopy(Blocks.SANDSTONE)));
+    public static final Supplier<Block> SMOOTH_SHELLSTONE_SLAB = registerBlock("smooth_shellstone_slab", () -> new SlabBlock(BlockBehaviour.Properties.ofFullCopy(Blocks.SANDSTONE)));
+    public static final Supplier<Block> SMOOTH_SHELLSTONE_WALL = registerBlock("smooth_shellstone_wall", () -> new WallBlock(BlockBehaviour.Properties.ofFullCopy(Blocks.SANDSTONE)));
 
 
     //region SPAWN EGGS

--- a/common/src/main/resources/data/minecraft/tags/entity_types/can_breathe_under_water.json
+++ b/common/src/main/resources/data/minecraft/tags/entity_types/can_breathe_under_water.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "naturalist:alligator",
+    "naturalist:hippo",
+    "naturalist:snail",
+    "naturalist:tortoise"
+  ]
+}

--- a/common/src/main/resources/data/naturalist/tags/blocks/butterflies_spawnable_on.json
+++ b/common/src/main/resources/data/naturalist/tags/blocks/butterflies_spawnable_on.json
@@ -4,6 +4,6 @@
     "minecraft:mud",
     "#minecraft:leaves",
     "#minecraft:flowers",
-    "minecraft:grass"
+    "minecraft:short_grass"
   ]
 }

--- a/common/src/main/resources/data/naturalist/tags/blocks/dragonflies_spawnable_on.json
+++ b/common/src/main/resources/data/naturalist/tags/blocks/dragonflies_spawnable_on.json
@@ -4,6 +4,6 @@
     "minecraft:mud",
     "#minecraft:leaves",
     "#minecraft:flowers",
-    "minecraft:grass"
+    "minecraft:short_grass"
   ]
 }

--- a/common/src/main/resources/data/naturalist/tags/blocks/rhino_charge_breakable.json
+++ b/common/src/main/resources/data/naturalist/tags/blocks/rhino_charge_breakable.json
@@ -2,7 +2,7 @@
   "values": [
     "#minecraft:crops",
     "#minecraft:flowers",
-    "minecraft:grass",
+    "minecraft:short_grass",
     "minecraft:fern",
     "minecraft:tall_grass",
     "minecraft:large_fern"

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -81,21 +81,13 @@ shadowJar {
 }
 
 remapJar {
-    archiveFileName.set("${project.archives_name}-${project.mod_version}+fabric-1.20.1.jar")
+    archiveFileName.set("${project.archives_name}-${project.mod_version}+fabric-${rootProject.minecraft_version}.jar")
     inputFile.set(shadowJar.archiveFile)
 }
 
 shadowJar {
     configurations = [project.configurations.shadowBundle]
     archiveClassifier = 'dev-shadow'
-}
-
-sourceSets {
-    main {
-        java {
-            srcDirs = ['src/main/java', 'src/main/resources']
-        }
-    }
 }
 
 components.java {

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -28,7 +28,7 @@
   ],
   "depends": {
     "fabric": "*",
-    "minecraft": ">=1.20.1",
+    "minecraft": ">=1.20.4 <1.20.5",
     "geckolib": ">=4.0.0"
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,20 +1,20 @@
 org.gradle.jvmargs=-Xmx3G
 
-minecraft_version=1.20.1
-enabled_platforms=fabric,forge
+minecraft_version=1.20.4
+enabled_platforms=fabric
 
 archives_name = naturalist
-mod_version = 5.0pre4
+mod_version = 5.0.0-pre.4
 maven_group = com.starfish_studios
 
-parchment_version = 2023.09.03
+parchment_version = 2024.04.14
 
 fabric_loader_version = 0.15.11
-fabric_api_version = 0.92.2+1.20.1
-geckolib_version = 4.7
-cloth_fabric_version = 8.2.88
-mod_menu_version = 7.2.2
-midnightlib_fabric_version = 1.4.1
+fabric_api_version = 0.97.3+1.20.4
+geckolib_version = 4.4.4
+cloth_fabric_version = 13.0.138
+mod_menu_version = 9.2.0-beta.2
+midnightlib_fabric_version = 1.5.3
 midnightlib_forge_version = 1.4.2
 
 forge_version = 1.20.1-47.1.3

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,5 @@ pluginManagement {
 
 include("common")
 include("fabric")
-include("forge")
 
 rootProject.name = "Naturalist"


### PR DESCRIPTION
## What changed

This ports the existing 1.20.1 Fabric code to Minecraft 1.20.4.

- updates Fabric API, GeckoLib, Cloth Config, Mod Menu, MidnightLib, and Parchment to their 1.20.4 versions
- updates vanilla API calls that changed between 1.20.1 and 1.20.4, including recipes, criteria, block codecs, dispenser access, riding positions, and melee attack checks
- replaces the renamed `grass` block tag entry with `short_grass`
- moves underwater breathing for alligators, hippos, snails, and tortoises to the vanilla 1.20.4 entity-type tag
- builds only the Fabric target because this branch is intended to provide the missing 1.20.4 Fabric artifact

## Why

The 1.20.1 Fabric jar cannot run unchanged on a 1.20.4 server because Minecraft's binary and data APIs changed. Updating only the declared Minecraft version still fails during startup. This PR updates the affected code paths so the mod can load normally on both the 1.20.4 client and dedicated server.

The gameplay and content are otherwise kept aligned with the existing 1.20.1 branch.

## Screenshots

Naturalist 5.0.0-pre.4 loaded in the Minecraft 1.20.4 Fabric development client:

![Naturalist 5.0.0-pre.4 loaded in Minecraft 1.20.4](https://raw.githubusercontent.com/jrepp/Naturalist/pr-assets-102/.github/pr-assets/102/naturalist-1.20.4-mod-details.png)

Naturalist giraffes and alligators rendered in a Minecraft 1.20.4 singleplayer world:

![Naturalist giraffes and alligators rendered in Minecraft 1.20.4](https://raw.githubusercontent.com/jrepp/Naturalist/pr-assets-102/.github/pr-assets/102/naturalist-1.20.4-animals.png)

## Validation

- `./gradlew clean :fabric:build`
- clean Minecraft 1.20.4 dedicated server with Fabric Loader 0.15.11, Fabric API 0.97.3, and GeckoLib 4.4.4
- server reached `Done` without Naturalist linkage, mixin, or data-tag errors
- server loaded 8 Naturalist recipes and applied 235 biome modifications
- successfully summoned Naturalist alligator and giraffe entities and placed a Naturalist shellstone block
- Fabric development client completed mixin and resource initialization and reached the title screen

The project does not currently contain automated test sources, so validation used the full Fabric build plus clean client and dedicated-server launches.
